### PR TITLE
feat: simulator CLI polish + refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,9 +750,11 @@ dependencies = [
  "consensus",
  "dag",
  "eyre",
+ "indicatif",
  "replica",
  "serde_yaml",
  "simulator",
+ "tabled",
  "terminal_size",
  "tokio",
  "tracing",
@@ -810,6 +812,19 @@ dependencies = [
  "serde",
  "tracing",
  "tracing-test",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1806,6 +1821,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width 0.2.2",
+ "web-time",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2091,6 +2119,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,6 +2293,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -3740,6 +3780,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3845,6 +3895,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,7 +16,9 @@ dag.workspace = true
 consensus.workspace = true
 replica.workspace = true
 simulator.workspace = true
+indicatif = "0.17"
 serde_yaml = { workspace = true }
+tabled = "0.12.2"
 terminal_size = "0.4.4"
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/cli/src/banner.rs
+++ b/crates/cli/src/banner.rs
@@ -1,20 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::io::IsTerminal;
-
 use terminal_size::terminal_size;
 use unicode_width::UnicodeWidthStr;
+
+use crate::reporter::{BLUE_BACKGROUND, BLUE_FOREGROUND, BOLD, DIM, RESET, stderr_supports_color};
 
 macro_rules! display {
     ($($arg:tt)*) => { eprintln!($($arg)*) };
 }
-
-const BLUE_FOREGROUND: &str = "\x1b[34m";
-const BLUE_BACKGROUND: &str = "\x1b[44m";
-const BOLD: &str = "\x1b[1m";
-const DIM: &str = "\x1b[2m";
-const RESET: &str = "\x1b[0m";
 
 const ART: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/assets/banner.txt"));
 
@@ -40,7 +34,7 @@ impl BannerPrinter {
                 .iter()
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
-            color: std::io::stderr().is_terminal(),
+            color: stderr_supports_color(),
             inner_width,
             top_border: format!("┌{border_fill}┐"),
             bottom_border: format!("└{border_fill}┘"),

--- a/crates/cli/src/commands/simulate.rs
+++ b/crates/cli/src/commands/simulate.rs
@@ -1,14 +1,14 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
+use std::{fmt, path::PathBuf};
 
 use dag::config::ImportExport;
-use eyre::{Result, bail, eyre};
-use simulator::{SimulationConfig, SimulationMode, SimulationRunner, SimulatorTracing};
+use eyre::{Result, bail};
+use simulator::{SimulationConfig, SimulationMode, SimulatorTracing};
 use tracing_subscriber::filter::LevelFilter;
 
-use crate::banner;
+use crate::reporter::{GREEN, RED, Reporter, YELLOW};
 
 pub async fn simulate(
     config_path: Option<PathBuf>,
@@ -41,41 +41,29 @@ pub async fn simulate(
         bail!("simulation suite is empty");
     }
 
-    banner::BannerPrinter::new(
+    let reporter = Reporter::new();
+    reporter.banner(
         "Mysticeti",
         &[
             ("Mode", "Simulator"),
             ("Simulations", &configs.len().to_string()),
         ],
-    )
-    .print();
+    );
 
     let total = configs.len();
+    let mut suite_rows = Vec::with_capacity(total);
     let mut diverged = 0;
     for (index, config) in configs.into_iter().enumerate() {
-        if total > 1 {
-            print_run_header(index + 1, total, &config);
-        }
-        let results = tokio::task::spawn_blocking(move || SimulationRunner::new(config).run())
-            .await
-            .map_err(|error| eyre!("Simulation task panicked: {error}"))?;
-
-        println!();
-        if results.commits_consistent {
-            println!("Commits consistent across all validators");
-        } else {
-            eprintln!("ERROR: Commits DIVERGED");
+        reporter.config_summary(index + 1, total, &config);
+        let (outcome, suite_row) = reporter.run(config).await?;
+        if outcome == Outcome::Diverged {
             diverged += 1;
         }
-        for (i, leaders) in results.committed_leaders.iter().enumerate() {
-            println!("  Validator {i}: {} committed leaders", leaders.len());
-        }
+        suite_rows.push(suite_row);
     }
 
     if total > 1 {
-        let consistent = total - diverged;
-        println!();
-        println!("{total} simulations run, {consistent} consistent, {diverged} diverged");
+        reporter.suite_summary(&suite_rows);
     }
 
     if diverged > 0 {
@@ -84,11 +72,63 @@ pub async fn simulate(
     Ok(())
 }
 
-fn print_run_header(index: usize, total: usize, config: &SimulationConfig) {
-    let label = config.name.as_deref().unwrap_or("unnamed");
-    println!();
-    println!(
-        "──── [{index}/{total}] {label} — {} nodes, {}s ────",
-        config.committee_size, config.duration_secs,
-    );
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// Safety held and at least one leader was committed somewhere.
+    Pass,
+    /// Safety held but no validator committed a single leader.
+    /// Expected under unrecoverable partitions (star, symmetric split).
+    NoProgress,
+    /// Safety violated: commit histories disagree.
+    Diverged,
+}
+
+impl Outcome {
+    pub fn from(consistent: bool, commit_counts: &[usize]) -> Self {
+        if !consistent {
+            return Self::Diverged;
+        }
+        if commit_counts.iter().all(|c| *c == 0) {
+            return Self::NoProgress;
+        }
+        Self::Pass
+    }
+
+    pub fn glyph(&self) -> &'static str {
+        match self {
+            Self::Pass => "✓",
+            Self::NoProgress => "⚠",
+            Self::Diverged => "✗",
+        }
+    }
+
+    pub fn message(&self) -> &'static str {
+        match self {
+            Self::Pass => "Commits consistent across all validators",
+            Self::NoProgress => "Safe but no leader was committed",
+            Self::Diverged => "Commits DIVERGED across validators",
+        }
+    }
+
+    pub fn color(&self) -> &'static str {
+        match self {
+            Self::Pass => GREEN,
+            Self::NoProgress => YELLOW,
+            Self::Diverged => RED,
+        }
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Pass => "PASS",
+            Self::NoProgress => "WARN",
+            Self::Diverged => "FAIL",
+        }
+    }
+}
+
+impl fmt::Display for Outcome {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.label(), self.message())
+    }
 }

--- a/crates/cli/src/commands/simulate.rs
+++ b/crates/cli/src/commands/simulate.rs
@@ -43,7 +43,7 @@ pub async fn simulate(
 
     let reporter = Reporter::new();
     reporter.banner(
-        "Mysticeti",
+        "Uncertified DAG",
         &[
             ("Mode", "Simulator"),
             ("Simulations", &configs.len().to_string()),

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -4,4 +4,6 @@
 pub mod args;
 pub mod banner;
 pub mod commands;
+pub mod reporter;
+pub mod table;
 pub mod tracing;

--- a/crates/cli/src/reporter.rs
+++ b/crates/cli/src/reporter.rs
@@ -1,0 +1,182 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{io::IsTerminal, time::Duration};
+
+use eyre::{Result, eyre};
+use indicatif::{ProgressBar, ProgressStyle};
+use simulator::{SimulationConfig, SimulationResults, SimulationRunner};
+
+use crate::{
+    banner::BannerPrinter,
+    commands::simulate::Outcome,
+    table::{self, ConfigRow, SuiteRow, ValidatorRow},
+};
+
+pub const BLUE_FOREGROUND: &str = "\x1b[34m";
+pub const BLUE_BACKGROUND: &str = "\x1b[44m";
+pub const BOLD: &str = "\x1b[1m";
+pub const DIM: &str = "\x1b[2m";
+pub const GREEN: &str = "\x1b[32m";
+pub const RED: &str = "\x1b[31m";
+pub const YELLOW: &str = "\x1b[33m";
+pub const RESET: &str = "\x1b[0m";
+
+/// True when stderr points at an interactive terminal and
+/// is therefore safe to emit ANSI escape codes to.
+pub fn stderr_supports_color() -> bool {
+    std::io::stderr().is_terminal()
+}
+
+/// Owns the terminal-capability flag and all presentation
+/// methods for the `simulate` command. One instance per
+/// invocation; methods borrow `&self`.
+pub struct Reporter {
+    color: bool,
+}
+
+impl Default for Reporter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Reporter {
+    pub fn new() -> Self {
+        Self {
+            color: stderr_supports_color(),
+        }
+    }
+
+    pub fn banner(&self, protocol: &str, info: &[(&str, &str)]) {
+        BannerPrinter::new(protocol, info).print();
+    }
+
+    pub fn config_summary(&self, index: usize, total: usize, config: &SimulationConfig) {
+        let heading = match (total > 1, config.name.as_deref()) {
+            (true, Some(name)) => Some(format!("Simulation [{index}/{total}]: {name}")),
+            (true, None) => Some(format!("Simulation [{index}/{total}]")),
+            (false, Some(name)) => Some(format!("Simulation: {name}")),
+            (false, None) => None,
+        };
+
+        println!();
+        if let Some(heading) = heading {
+            if self.color {
+                println!("{BOLD}{heading}{RESET}");
+            } else {
+                println!("{heading}");
+            }
+        }
+        println!("{}", table::render(ConfigRow::for_config(config)));
+    }
+
+    /// Execute one simulation: spinner → run → badge → per-validator
+    /// report. Returns the outcome and the suite-level row so the
+    /// caller can track suite-wide aggregates.
+    pub async fn run(&self, config: SimulationConfig) -> Result<(Outcome, SuiteRow)> {
+        let run_name = config.name.clone().unwrap_or_else(|| "unnamed".into());
+        let committee_size = config.committee_size;
+        let duration_secs = config.duration_secs;
+
+        let spinner = self.start_spinner();
+        let results = tokio::task::spawn_blocking(move || SimulationRunner::new(config).run())
+            .await
+            .map_err(|error| eyre!("Simulation task panicked: {error}"))?;
+        self.finish_spinner(spinner);
+
+        let commit_counts: Vec<usize> = results.committed_leaders.iter().map(|v| v.len()).collect();
+        let outcome = Outcome::from(results.commits_consistent, &commit_counts);
+        self.render_run(&results, duration_secs, outcome);
+        println!();
+
+        let suite_row = SuiteRow::new(
+            &run_name,
+            committee_size,
+            duration_secs,
+            outcome,
+            &commit_counts,
+        );
+        Ok((outcome, suite_row))
+    }
+
+    fn render_run(&self, results: &SimulationResults, duration_secs: u64, outcome: Outcome) {
+        self.run_badge(outcome);
+
+        let rows = ValidatorRow::for_results(results, duration_secs);
+
+        // Collapse to a single-line summary in the happy path when every
+        // validator committed the same leaders and nothing is noteworthy.
+        let commit_counts: Vec<usize> = results.committed_leaders.iter().map(|v| v.len()).collect();
+        let uniform_commits = commit_counts
+            .first()
+            .map(|first| commit_counts.iter().all(|c| c == first))
+            .unwrap_or(true);
+        let no_missing = rows.iter().all(|row| row.missing_blocks == "0");
+
+        if outcome != Outcome::Diverged && uniform_commits && no_missing {
+            let validators = rows.len();
+            let committed = commit_counts.first().copied().unwrap_or_default();
+            let rate = if duration_secs == 0 {
+                "— commits/s".into()
+            } else {
+                format!("{:.1} commits/s", committed as f64 / duration_secs as f64)
+            };
+            self.run_summary_line(validators, committed, &rate);
+            return;
+        }
+
+        self.validators_table(rows);
+    }
+
+    fn start_spinner(&self) -> Option<ProgressBar> {
+        if !self.color {
+            return None;
+        }
+        println!();
+        let spinner = ProgressBar::new_spinner();
+        spinner.set_style(
+            ProgressStyle::with_template(" {spinner} Simulating… {elapsed}")
+                .unwrap_or_else(|_| ProgressStyle::default_spinner()),
+        );
+        spinner.enable_steady_tick(Duration::from_millis(100));
+        Some(spinner)
+    }
+
+    fn finish_spinner(&self, spinner: Option<ProgressBar>) {
+        if let Some(spinner) = spinner {
+            spinner.finish_and_clear();
+        }
+    }
+
+    fn run_badge(&self, outcome: Outcome) {
+        if self.color {
+            println!(
+                "{color}{glyph} {message}{RESET}",
+                color = outcome.color(),
+                glyph = outcome.glyph(),
+                message = outcome.message(),
+            );
+        } else {
+            println!("{outcome}");
+        }
+    }
+
+    fn run_summary_line(&self, validators: usize, committed: usize, rate: &str) {
+        println!("  {validators} validators · {committed} committed leaders ({rate})");
+    }
+
+    fn validators_table(&self, rows: Vec<ValidatorRow>) {
+        println!("{}", table::render(rows));
+    }
+
+    pub fn suite_summary(&self, rows: &[SuiteRow]) {
+        println!();
+        if self.color {
+            println!("{BOLD}Suite summary{RESET}");
+        } else {
+            println!("Suite summary");
+        }
+        println!("{}", table::render(rows.iter().cloned()));
+    }
+}

--- a/crates/cli/src/table.rs
+++ b/crates/cli/src/table.rs
@@ -1,0 +1,140 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use dag::metrics::MetricsSnapshot;
+use simulator::{SimulationConfig, SimulationResults};
+use tabled::{Table, Tabled, settings::Style};
+
+use crate::commands::simulate::Outcome;
+
+/// Render any iterable of `Tabled` rows with the suite's
+/// standard rounded style. Single call site so the border
+/// style can change in one place.
+pub fn render<T: Tabled>(rows: impl IntoIterator<Item = T>) -> String {
+    Table::new(rows).with(Style::rounded()).to_string()
+}
+
+#[derive(Tabled)]
+pub struct ConfigRow {
+    #[tabled(rename = "parameter")]
+    parameter: String,
+    #[tabled(rename = "value")]
+    value: String,
+}
+
+impl ConfigRow {
+    pub fn for_config(config: &SimulationConfig) -> Vec<Self> {
+        vec![
+            Self::new("Committee size", config.committee_size.to_string()),
+            Self::new("Topology", config.topology.to_string()),
+            Self::new("Duration", format!("{}s", config.duration_secs)),
+            Self::new(
+                "Latency range",
+                format!("{}-{} ms", config.latency_min_ms, config.latency_max_ms),
+            ),
+            Self::new("RNG seed", config.rng_seed.to_string()),
+        ]
+    }
+
+    fn new(parameter: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            parameter: parameter.into(),
+            value: value.into(),
+        }
+    }
+}
+
+#[derive(Tabled)]
+pub struct ValidatorRow {
+    #[tabled(rename = "validator")]
+    validator: usize,
+    #[tabled(rename = "committed leaders")]
+    committed_leaders: usize,
+    #[tabled(rename = "commits/s")]
+    commits_per_sec: String,
+    #[tabled(rename = "leader timeouts")]
+    leader_timeouts: u64,
+    #[tabled(rename = "missing blocks")]
+    pub missing_blocks: String,
+    #[tabled(rename = "sync requests sent")]
+    sync_requests_sent: u64,
+}
+
+impl ValidatorRow {
+    pub fn for_results(results: &SimulationResults, duration_secs: u64) -> Vec<Self> {
+        results
+            .committed_leaders
+            .iter()
+            .zip(results.metrics.iter())
+            .enumerate()
+            .map(|(i, (leaders, metrics))| Self::new(i, leaders.len(), duration_secs, metrics))
+            .collect()
+    }
+
+    fn new(
+        index: usize,
+        committed_leaders: usize,
+        duration_secs: u64,
+        metrics: &MetricsSnapshot,
+    ) -> Self {
+        let authority = index.to_string();
+        let commits_per_sec = if duration_secs == 0 {
+            "—".into()
+        } else {
+            format!("{:.1}", committed_leaders as f64 / duration_secs as f64)
+        };
+        let leader_timeouts = metrics.metric("leader_timeout_total", &[]) as u64;
+        let missing_blocks = metrics.metric("missing_blocks", &[("authority", &authority)]) as i64;
+        let sync_requests_sent =
+            metrics.metric("block_sync_requests_sent", &[("authority", &authority)]) as u64;
+
+        Self {
+            validator: index,
+            committed_leaders,
+            commits_per_sec,
+            leader_timeouts,
+            missing_blocks: missing_blocks.to_string(),
+            sync_requests_sent,
+        }
+    }
+}
+
+#[derive(Tabled, Clone)]
+pub struct SuiteRow {
+    #[tabled(rename = "name")]
+    name: String,
+    #[tabled(rename = "nodes")]
+    nodes: usize,
+    #[tabled(rename = "duration")]
+    duration: String,
+    #[tabled(rename = "consistency")]
+    consistency: String,
+    #[tabled(rename = "committed leaders")]
+    committed_leaders: String,
+}
+
+impl SuiteRow {
+    pub fn new(
+        name: &str,
+        nodes: usize,
+        duration_secs: u64,
+        outcome: Outcome,
+        commit_counts: &[usize],
+    ) -> Self {
+        // Plain glyphs inside the table: tabled 0.12 sizes columns by
+        // raw byte length so ANSI colour escapes would skew alignment.
+        let consistency = outcome.glyph().into();
+        let committed_leaders = match (commit_counts.iter().min(), commit_counts.iter().max()) {
+            (Some(min), Some(max)) if min == max => format!("{min}"),
+            (Some(min), Some(max)) => format!("{min}–{max}"),
+            _ => "—".into(),
+        };
+        Self {
+            name: name.into(),
+            nodes,
+            duration: format!("{duration_secs}s"),
+            consistency,
+            committed_leaders,
+        }
+    }
+}

--- a/crates/consensus/src/protocol.rs
+++ b/crates/consensus/src/protocol.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
 /// that are fixed by the protocol (wave length, pipelining, quorum
 /// thresholds) are derived in `to_protocol`.
 #[derive(Serialize, Deserialize, Clone)]
-#[serde(tag = "type", rename_all = "camelCase")]
+#[serde(tag = "protocol", rename_all = "camelCase")]
 pub enum ConsensusProtocol {
     CordialMinersPartiallySynchronous,
     CordialMinersAsynchronous,

--- a/crates/dag/src/metrics/snapshot.rs
+++ b/crates/dag/src/metrics/snapshot.rs
@@ -18,11 +18,7 @@ impl MetricsSnapshot {
     }
 
     /// Read a metric by name and optional label key-value pairs.
-    pub fn metric(&self, name: &str, labels: &[(&str, &str)]) -> f64 {
-        self.find(name, labels)
-    }
-
-    fn find(&self, name: &str, label_values: &[(&str, &str)]) -> f64 {
+    pub fn metric(&self, name: &str, label_values: &[(&str, &str)]) -> f64 {
         for family in &self.families {
             if family.get_name() != name {
                 continue;

--- a/crates/orchestrator/assets/node-parameters.yml
+++ b/crates/orchestrator/assets/node-parameters.yml
@@ -3,5 +3,5 @@ dag:
     secs: 1
     nanos: 0
 consensus:
-  type: mysticeti
+  protocol: mysticeti
   leader_count: 2

--- a/crates/simulator/examples/single.yaml
+++ b/crates/simulator/examples/single.yaml
@@ -34,5 +34,5 @@ replica_parameters:
   #   cordialMinersPartiallySynchronous
   #   cordialMinersAsynchronous
   consensus:
-    type: mysticeti
+    protocol: mysticeti
     leader_count: 2

--- a/crates/simulator/examples/suite.yaml
+++ b/crates/simulator/examples/suite.yaml
@@ -1,0 +1,47 @@
+# Example simulation suite.
+#
+# The top-level YAML sequence lets you run several simulations sequentially
+# with one command. Each item is a full SimulationConfig: any field omitted
+# falls back to the same default as a single-config run (see default.yaml).
+#
+# Run with:
+#   cargo run -p cli -- simulate --config-path crates/simulator/examples/suite.yaml
+#
+# A final summary table is printed at the end showing each run's consistency
+# and committed-leader count.
+- name: baseline
+  committee_size: 4
+  duration_secs: 30
+- name: larger-committee
+  committee_size: 10
+  duration_secs: 30
+- name: high-latency
+  committee_size: 7
+  duration_secs: 30
+  latency_min_ms: 200
+  latency_max_ms: 400
+- name: one-down
+  committee_size: 7
+  duration_secs: 30
+  topology:
+    oneDown: 0
+- name: star
+  committee_size: 7
+  duration_secs: 30
+  topology:
+    star: 0
+- name: partition
+  committee_size: 6
+  duration_secs: 30
+  topology:
+    partition:
+      - [0, 1, 2]
+      - [3, 4, 5]
+- name: mahi-mahi
+  committee_size: 7
+  duration_secs: 30
+  replica_parameters:
+    consensus:
+      protocol: mahiMahi
+      leader_count: 2
+      wave_length: 4

--- a/crates/simulator/src/config.rs
+++ b/crates/simulator/src/config.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{ops::Range, time::Duration};
+use std::{fmt, ops::Range, time::Duration};
 
 use serde::{Deserialize, Serialize};
 
@@ -93,6 +93,33 @@ pub enum NetworkTopology {
     OneDown(usize),
     Partition(Vec<Vec<usize>>),
     Star(usize),
+}
+
+impl fmt::Display for NetworkTopology {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FullMesh => f.write_str("full mesh"),
+            Self::OneDown(index) => write!(f, "one down ({index})"),
+            Self::Star(center) => write!(f, "star (center={center})"),
+            Self::Partition(groups) => {
+                f.write_str("partition (")?;
+                for (i, group) in groups.iter().enumerate() {
+                    if i > 0 {
+                        f.write_str(",")?;
+                    }
+                    f.write_str("[")?;
+                    for (j, index) in group.iter().enumerate() {
+                        if j > 0 {
+                            f.write_str(",")?;
+                        }
+                        write!(f, "{index}")?;
+                    }
+                    f.write_str("]")?;
+                }
+                f.write_str(")")
+            }
+        }
+    }
 }
 
 mod defaults {

--- a/crates/simulator/src/tracing.rs
+++ b/crates/simulator/src/tracing.rs
@@ -25,7 +25,7 @@ impl SimulatorTracing {
     /// Set up simulator tracing with the default filter.
     /// `RUST_LOG` env var takes precedence.
     pub fn setup() {
-        Self::setup_with_filter("simulator=info,dag=info,dag::block_store=warn");
+        Self::setup_with_filter("simulator=warn,dag=warn");
     }
 
     /// Set up simulator tracing with an explicit filter

--- a/crates/simulator/tests/simulation.rs
+++ b/crates/simulator/tests/simulation.rs
@@ -119,7 +119,7 @@ fn custom_node_parameters() {
 
 #[test]
 fn from_example_config() {
-    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples/default.yaml");
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples/single.yaml");
     let runner = SimulationRunner::from_yaml(&path).unwrap();
     let results = runner.run();
 


### PR DESCRIPTION
Two commits on this branch:

1. `106cdca feat: nicer sim prints` — the bulk of the work.
2. `71a09c2 feat: rename banner title to "Uncertified DAG"` — a small follow-up.

## Summary
- Nicer simulator output: banner, pre-run config table, wall-clock spinner, per-run validator table (with one-line collapse on the happy path), suite summary table, three-state outcome (✓ pass / ⚠ no-progress / ✗ divergence).
- Refactored `crates/cli/src/commands/simulate.rs` (was ~360 lines, mixing orchestration, presentation, and table rendering) into three files:
  - `reporter.rs` — `Reporter` struct + ANSI constants + `stderr_supports_color`; owns the presentation surface (`banner`, `config_summary`, `run`, `suite_summary`).
  - `table.rs` — `ConfigRow`, `ValidatorRow`, `SuiteRow` + `render<T: Tabled>` helper.
  - `simulate.rs` — thin orchestration + `Outcome` enum with `glyph`/`message`/`color`/`impl fmt::Display`.
- `impl fmt::Display for NetworkTopology` replaces the local `format_topology` free fn.
- Default simulator log filter lowered from `info` to `warn` so the console isn't flooded by `dag::storage::reader` messages. `RUST_LOG` / `--log-level` still override.
- Banner title is now `Uncertified DAG` (protocol-neutral since suites can mix `mysticeti`, `mahiMahi`, etc.).
- New example suite at `crates/simulator/examples/suite.yaml` demonstrating varied topologies and protocols.

## Test plan
- [ ] `cargo run -p cli -- simulate` — banner, config table, spinner, consistency badge, one-line summary. Exit 0.
- [ ] `cargo run -p cli -- simulate --config-path crates/simulator/examples/suite.yaml` — per-run tables/one-liners plus final suite summary with ⚠ for `star`/`partition`. Exit 0.
- [ ] `cargo run -p cli -- simulate --dump-config` — unchanged YAML dump.
- [ ] `cargo run -p cli -- simulate 2>&1 | cat` — spinner suppressed, ANSI escapes stripped.
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)