### PR TITLE
fix: CI failures on main

### DIFF
--- a/.github/workflows/code.yaml
+++ b/.github/workflows/code.yaml
@@ -77,7 +77,7 @@ jobs:
           cargo tarpaulin \
             --workspace \
             --skip-clean \
-            --run-types Bins,Doctests,Examples,Lib,Tests \
+            --run-types Bins --run-types Doctests --run-types Examples --run-types Lib --run-types Tests \
             --out Html,Xml \
             --exclude-files "crates/**/benches/**/*" \
             --exclude-files "crates/**/tests/**/*" \

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -87,4 +87,5 @@ jobs:
       - name: Decide whether all needed jobs succeeded
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # pin@v1.2.2
         with:
+          allowed-skips: ${{ toJSON(needs) }}
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
- `cargo-tarpaulin` 0.35.1 no longer accepts the comma-separated form of `--run-types` — pass each value with its own flag so the `Test coverage` job runs on push to `main`.
- The `Lint` workflow's `check-all` gate uses `re-actors/alls-green` without `allowed-skips`, so the `pr-title` job (conditionally gated to `pull_request` events) causes the gate to fail on push to `main`. Add `allowed-skips` to mirror the `Code` workflow.

Both bugs only surface on push to `main`, which is why recent PRs pass but the same commits fail once merged.

## Test plan
- [ ] Push-to-main-equivalent CI run (this PR's own CI, since Lint runs the same check-all on PRs as well) shows `Lint` green.
- [ ] After merge, verify `Test coverage` on main completes without the `invalid value` tarpaulin error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)