### PR TITLE
fix: exclude skipped leaders from committed_leaders snapshot

### DIFF
--- a/crates/consensus/src/committer.rs
+++ b/crates/consensus/src/committer.rs
@@ -10,7 +10,7 @@ use dag::{
     committee::Committee,
     committee::Stake,
     consensus::{DagConsensus, LeaderStatus},
-    metrics::{CommitType, Metrics},
+    metrics::{DecisionType, Metrics},
     storage::BlockReader,
 };
 
@@ -119,12 +119,12 @@ impl Committer {
             .inspect(|x| tracing::debug!("Decided {x}"))
     }
 
-    /// Record this leader's commit outcome on `committed_leaders_total`. `Undecided` leaders
-    /// aren't a commit outcome, so `CommitType::classify` returns `None` and we skip emission.
+    /// Record this leader's decision outcome on `committed_leaders_total`. `Undecided` leaders
+    /// aren't a decision outcome, so `DecisionType::classify` returns `None` and we skip emission.
     fn update_metrics(&self, leader: &LeaderStatus, direct_decide: bool) {
-        if let Some(commit_type) = CommitType::classify(leader, direct_decide) {
+        if let Some(decision) = DecisionType::classify(leader, direct_decide) {
             self.metrics
-                .inc_committed_leaders(leader.authority(), commit_type);
+                .inc_committed_leaders(leader.authority(), decision);
         }
     }
 }

--- a/crates/dag/src/metrics.rs
+++ b/crates/dag/src/metrics.rs
@@ -18,7 +18,7 @@ use tokio::time::Instant;
 pub use self::aggregate::AggregateMetrics;
 pub(crate) use self::names::WORKLOAD_SHARED;
 pub use self::names::{
-    BENCHMARK_DURATION, BLOCK_SYNC_REQUESTS_SENT, CommitType, LABEL_AUTHORITY, LABEL_WORKLOAD,
+    BENCHMARK_DURATION, BLOCK_SYNC_REQUESTS_SENT, DecisionType, LABEL_AUTHORITY, LABEL_WORKLOAD,
     LATENCY_S, LATENCY_SQUARED_S, LEADER_TIMEOUT_TOTAL, SyncRequestFulfilled,
 };
 pub use self::snapshot::MetricsSnapshot;
@@ -144,11 +144,11 @@ impl Metrics {
             .observe(value);
     }
 
-    pub fn inc_committed_leaders(&self, authority: Authority, commit_type: CommitType) {
+    pub fn inc_committed_leaders(&self, authority: Authority, decision: DecisionType) {
         let label = authority.to_string();
         self.coarse
             .committed_leaders_total
-            .with_label_values(&[&label, commit_type.as_label()])
+            .with_label_values(&[&label, decision.as_label()])
             .inc();
     }
 
@@ -253,7 +253,7 @@ struct NetworkAddressTable {
 mod test {
     use std::time::Duration;
 
-    use super::{Authority, CommitType, Metrics};
+    use super::{Authority, DecisionType, Metrics};
 
     #[test]
     fn new_for_test_collect_roundtrip() {
@@ -280,9 +280,9 @@ mod test {
         let a = Authority::from(0_usize);
         let b = Authority::from(1_usize);
         let metrics = Metrics::new_for_test(4);
-        metrics.inc_committed_leaders(a, CommitType::DirectCommit);
-        metrics.inc_committed_leaders(a, CommitType::DirectCommit);
-        metrics.inc_committed_leaders(b, CommitType::IndirectSkip);
+        metrics.inc_committed_leaders(a, DecisionType::DirectCommit);
+        metrics.inc_committed_leaders(a, DecisionType::DirectCommit);
+        metrics.inc_committed_leaders(b, DecisionType::IndirectSkip);
         metrics.set_missing_blocks(a, 3);
         metrics.inc_block_sync_requests_sent(a);
         let snapshot = metrics.collect();
@@ -291,7 +291,7 @@ mod test {
                 "committed_leaders_total",
                 &[
                     ("authority", "A"),
-                    ("commit_type", CommitType::DirectCommit.as_label()),
+                    ("commit_type", DecisionType::DirectCommit.as_label()),
                 ]
             ),
             2.0
@@ -301,7 +301,7 @@ mod test {
                 "committed_leaders_total",
                 &[
                     ("authority", "B"),
-                    ("commit_type", CommitType::IndirectSkip.as_label()),
+                    ("commit_type", DecisionType::IndirectSkip.as_label()),
                 ]
             ),
             1.0

--- a/crates/dag/src/metrics/names.rs
+++ b/crates/dag/src/metrics/names.rs
@@ -42,18 +42,19 @@ pub const LABEL_PROC: &str = "proc";
 // Well-known label values (extracted when used in more than one place).
 pub const WORKLOAD_SHARED: &str = "shared";
 
-/// Canonical commit outcome for a leader slot, as recorded in the `commit_type` Prometheus label
-/// on `committed_leaders_total`. Producers classify a `(LeaderStatus, direct_decide)` pair into
-/// one of these four variants; consumers compare against `CommitType::as_label()` when reading.
+/// Canonical decision outcome for a leader slot, as recorded in the `commit_type` Prometheus
+/// label on `committed_leaders_total`. Producers classify a `(LeaderStatus, direct_decide)` pair
+/// into one of these four variants; consumers compare against `DecisionType::as_label()` when
+/// reading.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum CommitType {
+pub enum DecisionType {
     DirectCommit,
     IndirectCommit,
     DirectSkip,
     IndirectSkip,
 }
 
-impl CommitType {
+impl DecisionType {
     /// Canonical string used in the Prometheus `commit_type` label.
     pub fn as_label(&self) -> &'static str {
         match self {
@@ -64,8 +65,24 @@ impl CommitType {
         }
     }
 
+    /// Inverse of [`Self::as_label`]. Returns `None` for unknown label values.
+    pub fn from_label(label: &str) -> Option<Self> {
+        match label {
+            "direct-commit" => Some(Self::DirectCommit),
+            "indirect-commit" => Some(Self::IndirectCommit),
+            "direct-skip" => Some(Self::DirectSkip),
+            "indirect-skip" => Some(Self::IndirectSkip),
+            _ => None,
+        }
+    }
+
+    /// True when this decision committed the leader (as opposed to skipping it).
+    pub fn is_committed(&self) -> bool {
+        matches!(self, Self::DirectCommit | Self::IndirectCommit)
+    }
+
     /// Classify a `(LeaderStatus, direct_decide)` pair. Returns `None` for `Undecided` — it's not
-    /// a commit outcome, so callers should skip metric emission entirely in that case.
+    /// a decision outcome, so callers should skip metric emission entirely in that case.
     pub fn classify(leader: &LeaderStatus, direct: bool) -> Option<Self> {
         match (leader, direct) {
             (LeaderStatus::Commit(..), true) => Some(Self::DirectCommit),

--- a/crates/dag/src/metrics/snapshot.rs
+++ b/crates/dag/src/metrics/snapshot.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 use prometheus::proto::MetricFamily;
 
 use super::names::{
-    COMMITTED_LEADERS_TOTAL, LABEL_AUTHORITY, LABEL_WORKLOAD, LATENCY_S, MISSING_BLOCKS,
-    WORKLOAD_SHARED,
+    COMMITTED_LEADERS_TOTAL, DecisionType, LABEL_AUTHORITY, LABEL_COMMIT_TYPE, LABEL_WORKLOAD,
+    LATENCY_S, MISSING_BLOCKS, WORKLOAD_SHARED,
 };
 use crate::authority::Authority;
 
@@ -67,8 +67,8 @@ impl MetricsSnapshot {
         self.metric(MISSING_BLOCKS, &[(LABEL_AUTHORITY, &label)]) as i64
     }
 
-    /// Total committed leaders for `authority`, summed across all `commit_type` labels
-    /// (direct-commit, indirect-skip, ...).
+    /// Total leaders *committed* by `authority` — the commit rows of `committed_leaders_total`,
+    /// as identified by [`DecisionType::is_committed`]. Skipped leaders are excluded.
     pub fn committed_leaders(&self, authority: Authority) -> u64 {
         let label = authority.to_string();
         let mut total = 0.0;
@@ -77,11 +77,15 @@ impl MetricsSnapshot {
                 continue;
             }
             for metric in family.get_metric() {
-                let matches = metric
-                    .get_label()
+                let labels = metric.get_label();
+                let authority_matches = labels
                     .iter()
                     .any(|l| l.get_name() == LABEL_AUTHORITY && l.get_value() == label);
-                if matches && metric.has_counter() {
+                let is_commit = labels.iter().any(|l| {
+                    l.get_name() == LABEL_COMMIT_TYPE
+                        && DecisionType::from_label(l.get_value()).is_some_and(|d| d.is_committed())
+                });
+                if authority_matches && is_commit && metric.has_counter() {
                     total += metric.get_counter().get_value();
                 }
             }
@@ -135,7 +139,8 @@ impl MetricsSnapshot {
 
 #[cfg(test)]
 mod test {
-    use super::MetricsSnapshot;
+    use super::{DecisionType, MetricsSnapshot};
+    use crate::{authority::Authority, metrics::Metrics};
     use prometheus::{
         Registry, register_int_counter_vec_with_registry, register_int_counter_with_registry,
         register_int_gauge_with_registry,
@@ -183,6 +188,18 @@ mod test {
         let registry = Registry::new();
         let snapshot = collect_snapshot(&registry);
         assert_eq!(snapshot.metric("nonexistent", &[]), 0.0);
+    }
+
+    #[test]
+    fn committed_leaders_excludes_skips() {
+        let metrics = Metrics::new_for_test(4);
+        let a = Authority::from(0_usize);
+        metrics.inc_committed_leaders(a, DecisionType::DirectCommit);
+        metrics.inc_committed_leaders(a, DecisionType::IndirectCommit);
+        metrics.inc_committed_leaders(a, DecisionType::DirectSkip);
+        metrics.inc_committed_leaders(a, DecisionType::IndirectSkip);
+        let snapshot = metrics.collect();
+        assert_eq!(snapshot.committed_leaders(a), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `committed_leaders_total` is emitted with four `commit_type` values: `direct-commit`, `indirect-commit`, `direct-skip`, `indirect-skip`. The `MetricsSnapshot::committed_leaders` helper was summing all four, which made the sim summary report a nonzero `commits/s` for topologies that only *skipped* leaders. Example: `star` printed "0 commits, 0.0 commits/s" (small positive rate rounded to 0.0) while `partition` printed "— commits/s" — same real outcome (no commits), two different displays.
- Rename `CommitType` → `DecisionType` to reflect that the enum spans both commit and skip outcomes. Add `DecisionType::is_committed()` and `DecisionType::from_label()` helpers.
- Filter `MetricsSnapshot::committed_leaders` to rows where `DecisionType::is_committed()` is true, so the metric snapshot and the sim runner's `SimulationResults::commit_counts` (which only tracks actual committed leader blocks) agree.

## Test plan
- [x] `cargo test -p dag --lib` (new `committed_leaders_excludes_skips` snapshot test passes)
- [x] `cargo clippy --workspace --tests --no-deps`
- [ ] Re-run the failing `star` / `partition` sim scenarios; both should now report "— commits/s" when every leader was skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)