### PR TITLE
fix: repeat tarpaulin --out flag per value

### DIFF
--- a/.github/workflows/code.yaml
+++ b/.github/workflows/code.yaml
@@ -78,7 +78,7 @@ jobs:
             --workspace \
             --skip-clean \
             --run-types Bins --run-types Doctests --run-types Examples --run-types Lib --run-types Tests \
-            --out Html,Xml \
+            --out Html --out Xml \
             --exclude-files "crates/**/benches/**/*" \
             --exclude-files "crates/**/tests/**/*" \
             --exclude-files "crates/**/test_utils/**/*" \


### PR DESCRIPTION
## Summary
Follow-up to #35. The `Test coverage` job on `main` is still failing because tarpaulin 0.35.1 also rejects the comma-separated form of `--out`:

\`\`\`
error: invalid value 'Html,Xml' for '--out [<FMT>...]'
\`\`\`

Same shape as the `--run-types` fix: pass each format with its own flag.

## Test plan
- [ ] Next push to \`main\` completes the \`Test coverage\` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)