### PR TITLE
fix: drop Doctests and Examples from tarpaulin --run-types

### DIFF
--- a/.github/workflows/code.yaml
+++ b/.github/workflows/code.yaml
@@ -77,7 +77,7 @@ jobs:
           cargo tarpaulin \
             --workspace \
             --skip-clean \
-            --run-types Bins --run-types Doctests --run-types Examples --run-types Lib --run-types Tests \
+            --run-types Bins --run-types Lib --run-types Tests \
             --out Html --out Xml \
             --exclude-files "crates/**/benches/**/*" \
             --exclude-files "crates/**/tests/**/*" \


### PR DESCRIPTION
## Summary
Follow-up to #35 and #38. The \`--out\` fix let tarpaulin run, and it now fails inside the doctest-builder path with a rustup component-download race:

\`\`\`
error: component download failed for cargo-x86_64-unknown-linux-gnu: could not rename 'downloaded' file from '/home/runner/.rustup/downloads/....partial' ...
ERROR cargo_tarpaulin::cargo: Building doctests failed
\`\`\`

This repo has **zero doctests** and **zero \`.rs\` examples** (verified by grepping code-block doc comments and \`crates/**/examples/*.rs\`). Passing \`--run-types Doctests\` only triggers tarpaulin's fragile doctest-builder (requires coordination with rustup / sometimes nightly); passing \`--run-types Examples\` asks it to cover files that don't exist. Both are pure dead weight.

Keep the useful subset: Bins, Lib, Tests.

## Sources
- [xd009642/tarpaulin TROUBLESHOOTING](https://docs.rs/crate/cargo-tarpaulin/latest/source/TROUBLESHOOTING.md) — doctest caveats
- [xd009642/tarpaulin#402](https://github.com/xd009642/tarpaulin/issues/402) — doctest builder issues

## Test plan
- [ ] Next push to \`main\` completes the \`Test coverage\` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)