### PR TITLE
feat: add --log-file flag for non-blocking file logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,6 +758,7 @@ dependencies = [
  "terminal_size",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "unicode-width 0.2.2",
 ]
@@ -870,6 +871,21 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -3046,6 +3062,7 @@ version = "0.1.0"
 dependencies = [
  "consensus",
  "dag",
+ "eyre",
  "futures",
  "indoc",
  "parking_lot",
@@ -3056,6 +3073,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
 ]
 
@@ -3126,6 +3144,12 @@ name = "subtle-ng"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -3465,6 +3489,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ tokio = { version = "1.28.1", features = [
   "signal",
 ] }
 tracing = "0.1.37"
+tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 tracing-test = "0.2.4"
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,5 +22,6 @@ tabled = "0.12.2"
 terminal_size = "0.4.4"
 tokio = { workspace = true }
 tracing = { workspace = true }
+tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 unicode-width = "0.2.2"

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -16,6 +16,10 @@ pub struct Args {
     #[arg(long, global = true)]
     pub log_level: Option<LevelFilter>,
 
+    /// Write logs to this file instead of stderr.
+    #[arg(long, global = true, value_name = "FILE")]
+    pub log_file: Option<PathBuf>,
+
     #[command(subcommand)]
     pub command: Command,
 }

--- a/crates/cli/src/commands/genesis.rs
+++ b/crates/cli/src/commands/genesis.rs
@@ -16,12 +16,14 @@ pub fn test_genesis(
     working_directory: PathBuf,
     replica_parameters_path: Option<PathBuf>,
     log_level: Option<LevelFilter>,
+    log_file: Option<PathBuf>,
 ) -> Result<()> {
-    match log_level {
+    let _guard = match log_level {
         Some(level) => ReplicaTracing::new(level),
         None => ReplicaTracing::default(),
     }
-    .setup();
+    .with_log_file(log_file)
+    .setup()?;
 
     let committee_size = ips.len();
     tracing::info!("Generating test genesis for {committee_size} validators");

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -8,6 +8,8 @@ use replica::{
     config::{LoadGeneratorConfig, PrivateReplicaConfig, PublicReplicaConfig},
     prometheus::{MetricsRegistry, PrometheusServer},
 };
+use std::path::PathBuf;
+
 use tracing_subscriber::filter::LevelFilter;
 
 use crate::tracing::ReplicaTracing;
@@ -18,12 +20,14 @@ pub async fn run(
     private_config_path: String,
     load_generator_config_path: Option<String>,
     log_level: Option<LevelFilter>,
+    log_file: Option<PathBuf>,
 ) -> Result<()> {
-    match log_level {
+    let _guard = match log_level {
         Some(level) => ReplicaTracing::new(level),
         None => ReplicaTracing::default(),
     }
-    .setup();
+    .with_log_file(log_file)
+    .setup()?;
     tracing::info!("Starting replica {authority}");
 
     // Load configuration from YAML.

--- a/crates/cli/src/commands/simulate.rs
+++ b/crates/cli/src/commands/simulate.rs
@@ -14,6 +14,7 @@ pub async fn simulate(
     config_path: Option<PathBuf>,
     dump_config: bool,
     log_level: Option<LevelFilter>,
+    log_file: Option<PathBuf>,
 ) -> Result<()> {
     // Print default config to stdout and exit.
     if dump_config {
@@ -21,10 +22,11 @@ pub async fn simulate(
         return Ok(());
     }
 
-    match log_level {
-        Some(level) => SimulatorTracing::setup_with_filter(&level.to_string()),
-        None => SimulatorTracing::setup(),
-    };
+    let mut tracing = SimulatorTracing::new().with_log_file(log_file);
+    if let Some(level) = log_level {
+        tracing = tracing.with_filter(level.to_string());
+    }
+    let _guard = tracing.setup()?;
 
     let configs = match config_path {
         Some(path) => {

--- a/crates/cli/src/commands/testbed.rs
+++ b/crates/cli/src/commands/testbed.rs
@@ -23,12 +23,14 @@ pub async fn local_testbed(
     replica_parameters_path: Option<PathBuf>,
     load_generator_config_path: Option<PathBuf>,
     log_level: Option<LevelFilter>,
+    log_file: Option<PathBuf>,
 ) -> Result<()> {
-    match log_level {
+    let _guard = match log_level {
         Some(level) => ReplicaTracing::new(level),
         None => ReplicaTracing::new(LevelFilter::DEBUG),
     }
-    .setup();
+    .with_log_file(log_file)
+    .setup()?;
 
     // Load optional parameter overrides; fall back to defaults.
     let replica_parameters = match replica_parameters_path {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -23,6 +23,7 @@ async fn main() -> Result<()> {
             working_directory,
             replica_parameters_path,
             args.log_level,
+            args.log_file,
         )?,
         Command::Run {
             authority,
@@ -36,13 +37,17 @@ async fn main() -> Result<()> {
                 private_config_path,
                 load_generator_config_path,
                 args.log_level,
+                args.log_file,
             )
             .await?
         }
         Command::Simulate {
             config_path,
             dump_config,
-        } => commands::simulate::simulate(config_path, dump_config, args.log_level).await?,
+        } => {
+            commands::simulate::simulate(config_path, dump_config, args.log_level, args.log_file)
+                .await?
+        }
         Command::LocalTestbed {
             committee_size,
             replica_parameters_path,
@@ -53,6 +58,7 @@ async fn main() -> Result<()> {
                 replica_parameters_path,
                 load_generator_config_path,
                 args.log_level,
+                args.log_file,
             )
             .await?
         }

--- a/crates/cli/src/tracing.rs
+++ b/crates/cli/src/tracing.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{fs::File, path::PathBuf};
+
+use eyre::{Result, WrapErr};
+pub use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{EnvFilter, filter::LevelFilter, fmt};
 
 /// Our crate names for targeted filtering.
@@ -8,24 +12,36 @@ const TARGET_CRATES: &[&str] = &["dag", "consensus", "replica"];
 
 pub struct ReplicaTracing {
     level: LevelFilter,
+    log_file: Option<PathBuf>,
 }
 
 impl Default for ReplicaTracing {
     fn default() -> Self {
         Self {
             level: LevelFilter::INFO,
+            log_file: None,
         }
     }
 }
 
 impl ReplicaTracing {
     pub fn new(level: LevelFilter) -> Self {
-        Self { level }
+        Self {
+            level,
+            log_file: None,
+        }
     }
 
-    /// Only our crates are shown at the requested level; third-party
-    /// libraries are silenced to WARN. `RUST_LOG` overrides everything.
-    pub fn setup(self) {
+    pub fn with_log_file(mut self, path: Option<PathBuf>) -> Self {
+        self.log_file = path;
+        self
+    }
+
+    /// Only our crates are shown at the requested level; third-party libraries are silenced to
+    /// WARN. `RUST_LOG` overrides everything. When a log file is configured, logs go to the file
+    /// via a non-blocking background writer instead of stderr — bind the returned guard to a
+    /// `_guard` local so its `Drop` flushes buffered lines before the process exits.
+    pub fn setup(self) -> Result<Option<WorkerGuard>> {
         let mut filter = EnvFilter::builder()
             .with_default_directive(LevelFilter::WARN.into())
             .from_env_lossy();
@@ -34,6 +50,22 @@ impl ReplicaTracing {
                 filter = filter.add_directive(directive);
             }
         }
-        fmt().with_env_filter(filter).init();
+        match self.log_file {
+            Some(path) => {
+                let file = File::create(&path)
+                    .wrap_err_with(|| format!("opening log file {}", path.display()))?;
+                let (writer, guard) = tracing_appender::non_blocking(file);
+                fmt()
+                    .with_env_filter(filter)
+                    .with_writer(writer)
+                    .with_ansi(false)
+                    .init();
+                Ok(Some(guard))
+            }
+            None => {
+                fmt().with_env_filter(filter).init();
+                Ok(None)
+            }
+        }
     }
 }

--- a/crates/simulator/Cargo.toml
+++ b/crates/simulator/Cargo.toml
@@ -8,12 +8,14 @@ publish.workspace = true
 dag = { workspace = true, features = ["test-utils"] }
 consensus = { workspace = true, features = ["test-utils"] }
 replica.workspace = true
+eyre = { workspace = true }
 futures = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
 parking_lot = { workspace = true }
 

--- a/crates/simulator/src/runner.rs
+++ b/crates/simulator/src/runner.rs
@@ -89,7 +89,7 @@ impl SimulationRunner {
     /// Executes inside a deterministic discrete-event simulator:
     /// all time is simulated, no real wall-clock time elapses.
     pub fn run(self) -> SimulationResults {
-        SimulatorTracing::setup();
+        let _guard = SimulatorTracing::new().setup().ok();
         let rng = StdRng::seed_from_u64(self.config.rng_seed);
         SimulatorExecutor::run(rng, async {
             let duration = self.config.duration();

--- a/crates/simulator/src/tracing.rs
+++ b/crates/simulator/src/tracing.rs
@@ -1,9 +1,11 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
+use std::{env, fs::File, path::PathBuf};
 
+use eyre::{Result, WrapErr};
 use tracing::{Event, Subscriber, field::Visit};
+pub use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{
     fmt::{
         FmtContext, FormatEvent, FormatFields, format,
@@ -19,32 +21,67 @@ use dag::authority::Authority;
 
 use super::context::SimulatorContext;
 
-pub struct SimulatorTracing;
+const DEFAULT_FILTER: &str = "simulator=warn,dag=warn";
+
+#[derive(Default)]
+pub struct SimulatorTracing {
+    filter: Option<String>,
+    log_file: Option<PathBuf>,
+}
 
 impl SimulatorTracing {
-    /// Set up simulator tracing with the default filter.
-    /// `RUST_LOG` env var takes precedence.
-    pub fn setup() {
-        Self::setup_with_filter("simulator=warn,dag=warn");
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    /// Set up simulator tracing with an explicit filter
-    /// string. `RUST_LOG` env var takes precedence.
-    pub fn setup_with_filter(default_filter: &str) {
+    pub fn with_filter(mut self, filter: impl Into<String>) -> Self {
+        self.filter = Some(filter.into());
+        self
+    }
+
+    pub fn with_log_file(mut self, path: Option<PathBuf>) -> Self {
+        self.log_file = path;
+        self
+    }
+
+    /// Install the subscriber. `RUST_LOG` takes precedence over the configured filter. When a log
+    /// file is configured, logs go to the file via a non-blocking background writer instead of
+    /// stderr — bind the returned guard to a `_guard` local so its `Drop` flushes buffered lines
+    /// before the process exits.
+    pub fn setup(self) -> Result<Option<WorkerGuard>> {
+        let default_filter = self.filter.as_deref().unwrap_or(DEFAULT_FILTER);
         let env_log = env::var("RUST_LOG");
         let env_log = env_log.as_deref().unwrap_or(default_filter);
+        let filter = tracing_subscriber::EnvFilter::new(env_log);
         let fmt_layer = tracing_subscriber::fmt::layer()
             .with_timer(SimulatorTime)
             .event_format(SimulatorFormat(
                 format().with_timer(SimulatorTime).compact(),
             ));
-        let filter = tracing_subscriber::EnvFilter::new(env_log);
-        tracing_subscriber::registry()
-            .with(filter)
-            .with(AuthorityLayer)
-            .with(fmt_layer)
-            .try_init()
-            .ok();
+        match self.log_file {
+            Some(path) => {
+                let file = File::create(&path)
+                    .wrap_err_with(|| format!("opening log file {}", path.display()))?;
+                let (writer, guard) = tracing_appender::non_blocking(file);
+                let fmt_layer = fmt_layer.with_writer(writer).with_ansi(false);
+                tracing_subscriber::registry()
+                    .with(filter)
+                    .with(AuthorityLayer)
+                    .with(fmt_layer)
+                    .try_init()
+                    .ok();
+                Ok(Some(guard))
+            }
+            None => {
+                tracing_subscriber::registry()
+                    .with(filter)
+                    .with(AuthorityLayer)
+                    .with(fmt_layer)
+                    .try_init()
+                    .ok();
+                Ok(None)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Adds a global \`--log-file <PATH>\` CLI flag that routes all log output to a file instead of stderr. The terminal then shows only reporter output (banners, tables, summaries).

Under the hood: \`tracing_appender::non_blocking\` — the appender runs on a background thread and every log call does a bounded-channel send, so there's no synchronous disk I/O on the hot path. That makes the flag safe for the real \`run\` subcommand (production replica) as well as for \`simulate\` and \`local-testbed\`. One implementation, no "sim/testbed only" carve-out.

## Key design choices
- Global flag on \`Args\` (\`crates/cli/src/args.rs\`).
- \`ReplicaTracing\` and \`SimulatorTracing\` both gain \`with_log_file(Option<PathBuf>)\` and return \`Option<WorkerGuard>\` from \`setup()\`. Each subcommand binds \`let _guard = ...setup()?;\` so the guard's \`Drop\` flushes buffered lines before the process exits.
- When \`--log-file\` is absent, the subscriber tree is byte-identical to before (same filter defaults, \`RUST_LOG\` precedence, stderr writer, ANSI, timer, layer stack). Zero overhead on the unmodified path.
- \`setup()\` returns \`eyre::Result<...>\` so a bad path fails fast at startup instead of being silently swallowed.

## Test plan
- [x] \`cargo build --workspace\`
- [x] \`cargo test -p cli -p simulator --lib\` (existing \`span_authority_propagates_through_none_scope\` still passes)
- [x] \`cargo clippy --workspace --tests --no-deps -- -D warnings\`
- [x] \`simulate --log-file /tmp/sim.log --log-level debug\` → terminal clean, ~11 MB / 85 k lines in file, simulator format preserved (\`[A] +00000\`), tail present (guard flush confirmed)
- [x] \`local-testbed --log-file /tmp/testbed.log\` → stdout has banner only, ~19 MB / 163 k lines in file
- [x] Bad path (\`/does/not/exist/...\`) → fails fast with \`opening log file ...\` error
- [x] Refactor-guardian agent: SAFE (no regressions, no lifetime bugs, byte-equivalent behavior when flag absent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)