### PR TITLE
fix: emit committed_leaders_total once per decided leader

### DIFF
--- a/crates/consensus/src/base.rs
+++ b/crates/consensus/src/base.rs
@@ -198,8 +198,8 @@ impl BaseCommitter {
         }
 
         match first {
-            Some(block) => LeaderStatus::Commit(block.clone()),
-            None => LeaderStatus::Skip(leader, leader_round),
+            Some(block) => LeaderStatus::IndirectCommit(block.clone()),
+            None => LeaderStatus::IndirectSkip(leader, leader_round),
         }
     }
 
@@ -279,10 +279,10 @@ impl BaseCommitter {
                 leader.with_round(leader_round),
             );
             match anchor {
-                LeaderStatus::Commit(anchor) => {
+                LeaderStatus::DirectCommit(anchor) | LeaderStatus::IndirectCommit(anchor) => {
                     return self.decide_leader_from_anchor(anchor, leader, leader_round);
                 }
-                LeaderStatus::Skip(..) => (),
+                LeaderStatus::DirectSkip(..) | LeaderStatus::IndirectSkip(..) => (),
                 LeaderStatus::Undecided(..) => break,
             }
         }
@@ -309,7 +309,7 @@ impl BaseCommitter {
         // Check whether the leader has enough blame. That is, whether there are 2f+1 non-votes
         // for that leader (which ensure there will never be a certificate for that leader).
         if self.enough_leader_blame(voting_round, leader, leader_round) {
-            return LeaderStatus::Skip(leader, leader_round);
+            return LeaderStatus::DirectSkip(leader, leader_round);
         }
 
         // Check whether the leader(s) has enough support. That is, whether there are 2f+1
@@ -330,7 +330,7 @@ impl BaseCommitter {
         }
 
         first
-            .map(LeaderStatus::Commit)
+            .map(LeaderStatus::DirectCommit)
             .unwrap_or_else(|| LeaderStatus::Undecided(leader, leader_round))
     }
 }

--- a/crates/consensus/src/committer.rs
+++ b/crates/consensus/src/committer.rs
@@ -10,7 +10,6 @@ use dag::{
     committee::Committee,
     committee::Stake,
     consensus::{DagConsensus, LeaderStatus},
-    metrics::{DecisionType, Metrics},
     storage::BlockReader,
 };
 
@@ -22,18 +21,12 @@ pub struct Committer {
     base_committers: Vec<BaseCommitter>,
     strong_quorum: Stake,
     leader_wait: bool,
-    metrics: Arc<Metrics>,
     /// Reusable buffer for commit decisions.
     leaders: VecDeque<LeaderStatus>,
 }
 
 impl Committer {
-    pub fn new(
-        committee: Arc<Committee>,
-        block_reader: BlockReader,
-        protocol: Protocol,
-        metrics: Arc<Metrics>,
-    ) -> Self {
+    pub fn new(committee: Arc<Committee>, block_reader: BlockReader, protocol: Protocol) -> Self {
         let mut base_committers = Vec::new();
         let pipeline_stages = if protocol.pipeline {
             protocol.wave_length
@@ -60,7 +53,6 @@ impl Committer {
             base_committers,
             strong_quorum: protocol.strong_quorum,
             leader_wait: protocol.leader_wait,
-            metrics,
             leaders: VecDeque::new(),
         }
     }
@@ -91,13 +83,11 @@ impl Committer {
 
                 // Try to directly decide the leader.
                 let mut status = committer.try_direct_decide(leader, round);
-                self.update_metrics(&status, true);
                 tracing::debug!("Outcome of direct rule: {status}");
 
                 // If we can't directly decide the leader, try to indirectly decide it.
                 if !status.is_decided() {
                     status = committer.try_indirect_decide(leader, round, self.leaders.iter());
-                    self.update_metrics(&status, false);
                     tracing::debug!("Outcome of indirect rule: {status}");
                 }
 
@@ -117,15 +107,6 @@ impl Committer {
             // Stop the sequence upon encountering an undecided leader.
             .take_while(|x| x.is_decided())
             .inspect(|x| tracing::debug!("Decided {x}"))
-    }
-
-    /// Record this leader's decision outcome on `committed_leaders_total`. `Undecided` leaders
-    /// aren't a decision outcome, so `DecisionType::classify` returns `None` and we skip emission.
-    fn update_metrics(&self, leader: &LeaderStatus, direct_decide: bool) {
-        if let Some(decision) = DecisionType::classify(leader, direct_decide) {
-            self.metrics
-                .inc_committed_leaders(leader.authority(), decision);
-        }
     }
 }
 

--- a/crates/consensus/src/test_util.rs
+++ b/crates/consensus/src/test_util.rs
@@ -30,12 +30,7 @@ fn open_core<C: Ctx>(
         Storage::new_for_tests(authority, metrics.clone(), committee)
     };
     let protocol = ConsensusProtocol::default().to_protocol(committee.total_stake());
-    let committer = Committer::new(
-        committee.clone(),
-        storage.block_reader().clone(),
-        protocol,
-        metrics.clone(),
-    );
+    let committer = Committer::new(committee.clone(), storage.block_reader().clone(), protocol);
     let (block_handler, _tx_sender) = RealBlockHandler::new(metrics.clone());
     let crypto = CryptoEngine::disabled();
     Core::open(

--- a/crates/consensus/src/tests/base_committer_tests.rs
+++ b/crates/consensus/src/tests/base_committer_tests.rs
@@ -36,7 +36,6 @@ fn direct_commit() {
             leader_wait: false,
             require_crypto: false,
         },
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);
@@ -44,7 +43,9 @@ fn direct_commit() {
     tracing::info!("Commit sequence: {sequence:?}");
 
     assert_eq!(sequence.len(), 1);
-    if let LeaderStatus::Commit(ref block) = sequence[0] {
+    if let LeaderStatus::DirectCommit(ref block) | LeaderStatus::IndirectCommit(ref block) =
+        sequence[0]
+    {
         assert_eq!(block.author(), leader_elector.elect_leader(3))
     } else {
         panic!("Expected a committed leader")
@@ -73,7 +74,6 @@ fn idempotence() {
             leader_wait: false,
             require_crypto: false,
         },
-        Metrics::new_for_test(0),
     );
 
     // Commit one block.
@@ -115,7 +115,6 @@ fn multiple_direct_commit() {
                 leader_wait: false,
                 require_crypto: false,
             },
-            Metrics::new_for_test(0),
         );
 
         let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
@@ -123,7 +122,9 @@ fn multiple_direct_commit() {
         assert_eq!(sequence.len(), 1);
 
         let leader_round = n * wave_length;
-        if let LeaderStatus::Commit(ref block) = sequence[0] {
+        if let LeaderStatus::DirectCommit(ref block) | LeaderStatus::IndirectCommit(ref block) =
+            sequence[0]
+        {
             assert_eq!(block.author(), leader_elector.elect_leader(leader_round));
         } else {
             panic!("Expected a committed leader")
@@ -160,7 +161,6 @@ fn direct_commit_late_call() {
             leader_wait: false,
             require_crypto: false,
         },
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);
@@ -170,7 +170,9 @@ fn direct_commit_late_call() {
     assert_eq!(sequence.len(), n as usize);
     for (i, leader_block) in sequence.iter().enumerate() {
         let leader_round = (i as u64 + 1) * wave_length;
-        if let LeaderStatus::Commit(block) = leader_block {
+        if let LeaderStatus::DirectCommit(block) | LeaderStatus::IndirectCommit(block) =
+            leader_block
+        {
             assert_eq!(block.author(), leader_elector.elect_leader(leader_round));
         } else {
             panic!("Expected a committed leader")
@@ -203,7 +205,6 @@ fn no_genesis_commit() {
                 leader_wait: false,
                 require_crypto: false,
             },
-            Metrics::new_for_test(0),
         );
 
         let last_committed = BlockReference::new_test(0, 0);
@@ -254,7 +255,6 @@ fn no_leader() {
             leader_wait: false,
             require_crypto: false,
         },
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);
@@ -262,7 +262,9 @@ fn no_leader() {
     tracing::info!("Commit sequence: {sequence:?}");
 
     assert_eq!(sequence.len(), 1);
-    if let LeaderStatus::Skip(leader, round) = sequence[0] {
+    if let LeaderStatus::DirectSkip(leader, round) | LeaderStatus::IndirectSkip(leader, round) =
+        sequence[0]
+    {
         assert_eq!(leader, leader_1);
         assert_eq!(round, leader_round_1);
     } else {
@@ -313,7 +315,6 @@ fn direct_skip() {
             leader_wait: false,
             require_crypto: false,
         },
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);
@@ -321,7 +322,9 @@ fn direct_skip() {
     tracing::info!("Commit sequence: {sequence:?}");
 
     assert_eq!(sequence.len(), 1);
-    if let LeaderStatus::Skip(leader, round) = sequence[0] {
+    if let LeaderStatus::DirectSkip(leader, round) | LeaderStatus::IndirectSkip(leader, round) =
+        sequence[0]
+    {
         assert_eq!(leader, leader_elector.elect_leader(leader_round_1));
         assert_eq!(round, leader_round_1);
     } else {
@@ -421,7 +424,6 @@ fn indirect_commit() {
             leader_wait: false,
             require_crypto: false,
         },
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);
@@ -431,7 +433,9 @@ fn indirect_commit() {
 
     let leader_round = wave_length;
     let leader = leader_elector.elect_leader(leader_round);
-    if let LeaderStatus::Commit(ref block) = sequence[0] {
+    if let LeaderStatus::DirectCommit(ref block) | LeaderStatus::IndirectCommit(ref block) =
+        sequence[0]
+    {
         assert_eq!(block.author(), leader);
     } else {
         panic!("Expected a committed leader")
@@ -497,7 +501,6 @@ fn indirect_skip() {
             leader_wait: false,
             require_crypto: false,
         },
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);
@@ -508,7 +511,9 @@ fn indirect_skip() {
     // Ensure we commit the leader of wave 1.
     let leader_round_1 = wave_length;
     let leader_1 = leader_elector.elect_leader(leader_round_1);
-    if let LeaderStatus::Commit(ref block) = sequence[0] {
+    if let LeaderStatus::DirectCommit(ref block) | LeaderStatus::IndirectCommit(ref block) =
+        sequence[0]
+    {
         assert_eq!(block.author(), leader_1);
     } else {
         panic!("Expected a committed leader")
@@ -516,7 +521,9 @@ fn indirect_skip() {
 
     // Ensure we skip the 2nd leader.
     let leader_round_2 = 2 * wave_length;
-    if let LeaderStatus::Skip(leader, round) = sequence[1] {
+    if let LeaderStatus::DirectSkip(leader, round) | LeaderStatus::IndirectSkip(leader, round) =
+        sequence[1]
+    {
         assert_eq!(leader, leader_2);
         assert_eq!(round, leader_round_2);
     } else {
@@ -526,7 +533,9 @@ fn indirect_skip() {
     // Ensure we commit the 3rd leader.
     let leader_round_3 = 3 * wave_length;
     let leader_3 = leader_elector.elect_leader(leader_round_3);
-    if let LeaderStatus::Commit(ref block) = sequence[2] {
+    if let LeaderStatus::DirectCommit(ref block) | LeaderStatus::IndirectCommit(ref block) =
+        sequence[2]
+    {
         assert_eq!(block.author(), leader_3);
     } else {
         panic!("Expected a committed leader")
@@ -585,7 +594,6 @@ fn undecided() {
             leader_wait: false,
             require_crypto: false,
         },
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);

--- a/crates/consensus/src/tests/multi_committer_tests.rs
+++ b/crates/consensus/src/tests/multi_committer_tests.rs
@@ -37,7 +37,6 @@ fn direct_commit() {
                 leader_wait: false,
                 require_crypto: false,
             },
-            Metrics::new_for_test(0),
         );
 
         let last_committed = BlockReference::new_test(0, 0);
@@ -46,7 +45,8 @@ fn direct_commit() {
 
         assert_eq!(sequence.len(), leader_count);
         for (i, leader) in sequence.iter().enumerate() {
-            if let LeaderStatus::Commit(block) = leader {
+            if let LeaderStatus::DirectCommit(block) | LeaderStatus::IndirectCommit(block) = leader
+            {
                 let leader_round = wave_length;
                 let leader_offset = i as u64;
                 let expected = leader_elector.elect_leader(leader_round + leader_offset);
@@ -80,7 +80,6 @@ fn idempotence() {
                 leader_wait: false,
                 require_crypto: false,
             },
-            Metrics::new_for_test(0),
         );
 
         // Commit one block.
@@ -126,7 +125,6 @@ fn multiple_direct_commit() {
                 leader_wait: false,
                 require_crypto: false,
             },
-            Metrics::new_for_test(0),
         );
 
         let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
@@ -135,7 +133,8 @@ fn multiple_direct_commit() {
 
         let leader_round = n * wave_length;
         for (i, leader) in sequence.iter().enumerate() {
-            if let LeaderStatus::Commit(block) = leader {
+            if let LeaderStatus::DirectCommit(block) | LeaderStatus::IndirectCommit(block) = leader
+            {
                 let leader_offset = i as u64;
                 let expected = leader_elector.elect_leader(leader_round + leader_offset);
                 assert_eq!(block.author(), expected);
@@ -181,7 +180,6 @@ fn direct_commit_partial_round() {
             leader_wait: false,
             require_crypto: false,
         },
-        Metrics::new_for_test(0),
     );
 
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
@@ -189,7 +187,7 @@ fn direct_commit_partial_round() {
     assert_eq!(sequence.len(), leader_count - 1);
 
     for (i, leader) in sequence.iter().enumerate() {
-        if let LeaderStatus::Commit(block) = leader {
+        if let LeaderStatus::DirectCommit(block) | LeaderStatus::IndirectCommit(block) = leader {
             let leader_offset = (i + 1) % committee.len();
             let expected = leader_elector.elect_leader(first_leader_round + leader_offset as u64);
             assert_eq!(block.author(), expected);
@@ -228,7 +226,6 @@ fn direct_commit_late_call() {
             leader_wait: false,
             require_crypto: false,
         },
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);
@@ -239,7 +236,8 @@ fn direct_commit_late_call() {
     for (i, leaders) in sequence.chunks(leader_count).enumerate() {
         let leader_round = (i as u64 + 1) * wave_length;
         for (j, leader) in leaders.iter().enumerate() {
-            if let LeaderStatus::Commit(block) = leader {
+            if let LeaderStatus::DirectCommit(block) | LeaderStatus::IndirectCommit(block) = leader
+            {
                 let leader_offset = j as u64;
                 let expected = leader_elector.elect_leader(leader_round + leader_offset);
                 assert_eq!(block.author(), expected);
@@ -278,7 +276,6 @@ fn no_genesis_commit() {
                 leader_wait: false,
                 require_crypto: false,
             },
-            Metrics::new_for_test(0),
         );
 
         let last_committed = BlockReference::new_test(0, 0);
@@ -332,7 +329,6 @@ fn no_leader() {
             leader_wait: false,
             require_crypto: false,
         },
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);
@@ -345,13 +341,17 @@ fn no_leader() {
         let leader_offset = i as u64;
         let expected_leader = leader_elector.elect_leader(leader_round + leader_offset);
         if i == 0 {
-            if let LeaderStatus::Skip(leader, round) = sequence[i] {
+            if let LeaderStatus::DirectSkip(leader, round)
+            | LeaderStatus::IndirectSkip(leader, round) = sequence[i]
+            {
                 assert_eq!(leader, expected_leader);
                 assert_eq!(round, leader_round_1);
             } else {
                 panic!("Expected to directly skip the leader");
             }
-        } else if let LeaderStatus::Commit(block) = leader {
+        } else if let LeaderStatus::DirectCommit(block) | LeaderStatus::IndirectCommit(block) =
+            leader
+        {
             assert_eq!(block.author(), expected_leader);
         } else {
             panic!("Expected a committed leader")
@@ -405,7 +405,6 @@ fn direct_skip() {
             leader_wait: false,
             require_crypto: false,
         },
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);
@@ -418,13 +417,17 @@ fn direct_skip() {
         let leader_offset = i as u64;
         let expected_leader = leader_elector.elect_leader(leader_round + leader_offset);
         if i == 0 {
-            if let LeaderStatus::Skip(leader, round) = sequence[i] {
+            if let LeaderStatus::DirectSkip(leader, round)
+            | LeaderStatus::IndirectSkip(leader, round) = sequence[i]
+            {
                 assert_eq!(leader, expected_leader);
                 assert_eq!(round, leader_round_1);
             } else {
                 panic!("Expected to directly skip the leader");
             }
-        } else if let LeaderStatus::Commit(block) = leader {
+        } else if let LeaderStatus::DirectCommit(block) | LeaderStatus::IndirectCommit(block) =
+            leader
+        {
             assert_eq!(block.author(), expected_leader);
         } else {
             panic!("Expected a committed leader")
@@ -525,7 +528,6 @@ fn indirect_commit() {
             leader_wait: false,
             require_crypto: false,
         },
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);
@@ -535,7 +537,9 @@ fn indirect_commit() {
 
     let leader_round = wave_length;
     let leader = leader_elector.elect_leader(leader_round);
-    if let LeaderStatus::Commit(ref block) = sequence[0] {
+    if let LeaderStatus::DirectCommit(ref block) | LeaderStatus::IndirectCommit(ref block) =
+        sequence[0]
+    {
         assert_eq!(block.author(), leader);
     } else {
         panic!("Expected a committed leader")
@@ -603,7 +607,6 @@ fn indirect_skip() {
             leader_wait: false,
             require_crypto: false,
         },
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);
@@ -616,7 +619,7 @@ fn indirect_skip() {
         let leader_round_1 = wave_length;
         let leader_offset = n as u64;
         let leader_1 = leader_elector.elect_leader(leader_round_1 + leader_offset);
-        if let LeaderStatus::Commit(block) = status {
+        if let LeaderStatus::DirectCommit(block) | LeaderStatus::IndirectCommit(block) = status {
             assert_eq!(block.author(), leader_1);
         } else {
             panic!("Expected a committed leader")
@@ -625,7 +628,9 @@ fn indirect_skip() {
 
     // Ensure we skip the first leader of wave 2 but commit the other leaders of wave 2.
     let leader_round_2 = 2 * wave_length;
-    if let LeaderStatus::Skip(leader, round) = sequence[leader_count] {
+    if let LeaderStatus::DirectSkip(leader, round) | LeaderStatus::IndirectSkip(leader, round) =
+        sequence[leader_count]
+    {
         assert_eq!(leader, leader_2);
         assert_eq!(round, leader_round_2);
     } else {
@@ -636,7 +641,9 @@ fn indirect_skip() {
         let leader_round_2 = 2 * wave_length;
         let leader_offset = n as u64;
         if n == 0 {
-            if let LeaderStatus::Skip(leader, round) = sequence[leader_count + n] {
+            if let LeaderStatus::DirectSkip(leader, round)
+            | LeaderStatus::IndirectSkip(leader, round) = sequence[leader_count + n]
+            {
                 assert_eq!(leader, leader_2);
                 assert_eq!(round, leader_round_2);
             } else {
@@ -644,7 +651,9 @@ fn indirect_skip() {
             }
         } else {
             let leader_2 = leader_elector.elect_leader(leader_round_2 + leader_offset);
-            if let LeaderStatus::Commit(ref block) = sequence[leader_count + n] {
+            if let LeaderStatus::DirectCommit(ref block) | LeaderStatus::IndirectCommit(ref block) =
+                sequence[leader_count + n]
+            {
                 assert_eq!(block.author(), leader_2);
             } else {
                 panic!("Expected a committed leader")
@@ -657,7 +666,9 @@ fn indirect_skip() {
         let leader_round_3 = 3 * wave_length;
         let leader_offset = n as u64;
         let leader_3 = leader_elector.elect_leader(leader_round_3 + leader_offset);
-        if let LeaderStatus::Commit(ref block) = sequence[2 * leader_count + n] {
+        if let LeaderStatus::DirectCommit(ref block) | LeaderStatus::IndirectCommit(ref block) =
+            sequence[2 * leader_count + n]
+        {
             assert_eq!(block.author(), leader_3);
         } else {
             panic!("Expected a committed leader")
@@ -718,7 +729,6 @@ fn undecided() {
             leader_wait: false,
             require_crypto: false,
         },
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);

--- a/crates/consensus/src/tests/pipelined_committer_tests.rs
+++ b/crates/consensus/src/tests/pipelined_committer_tests.rs
@@ -31,7 +31,6 @@ fn direct_commit() {
         committee.clone(),
         storage.block_reader().clone(),
         Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);
@@ -39,7 +38,9 @@ fn direct_commit() {
     tracing::info!("Commit sequence: {sequence:?}");
 
     assert_eq!(sequence.len(), 1);
-    if let LeaderStatus::Commit(ref block) = sequence[0] {
+    if let LeaderStatus::DirectCommit(ref block) | LeaderStatus::IndirectCommit(ref block) =
+        sequence[0]
+    {
         assert_eq!(block.author(), leader_elector.elect_leader(1));
     } else {
         panic!("Expected a committed leader")
@@ -60,7 +61,6 @@ fn idempotence() {
         committee.clone(),
         storage.block_reader().clone(),
         Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
-        Metrics::new_for_test(0),
     );
 
     // Commit one block.
@@ -94,7 +94,6 @@ fn multiple_direct_commit() {
             committee.clone(),
             storage.block_reader().clone(),
             Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
-            Metrics::new_for_test(0),
         );
 
         let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
@@ -102,7 +101,9 @@ fn multiple_direct_commit() {
 
         assert_eq!(sequence.len(), 1);
         let leader_round = n;
-        if let LeaderStatus::Commit(ref block) = sequence[0] {
+        if let LeaderStatus::DirectCommit(ref block) | LeaderStatus::IndirectCommit(ref block) =
+            sequence[0]
+        {
             assert_eq!(block.author(), leader_elector.elect_leader(leader_round));
         } else {
             panic!("Expected a committed leader")
@@ -131,7 +132,6 @@ fn direct_commit_late_call() {
         committee.clone(),
         storage.block_reader().clone(),
         Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);
@@ -141,7 +141,9 @@ fn direct_commit_late_call() {
     assert_eq!(sequence.len(), n as usize);
     for (i, leader_block) in sequence.iter().enumerate() {
         let leader_round = 1 + i as u64;
-        if let LeaderStatus::Commit(block) = leader_block {
+        if let LeaderStatus::DirectCommit(block) | LeaderStatus::IndirectCommit(block) =
+            leader_block
+        {
             assert_eq!(block.author(), leader_elector.elect_leader(leader_round));
         } else {
             panic!("Expected a committed leader")
@@ -166,7 +168,6 @@ fn no_genesis_commit() {
             committee.clone(),
             storage.block_reader().clone(),
             Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
-            Metrics::new_for_test(0),
         );
 
         let last_committed = BlockReference::new_test(0, 0);
@@ -209,7 +210,6 @@ fn no_leader() {
         committee.clone(),
         storage.block_reader().clone(),
         Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);
@@ -217,7 +217,9 @@ fn no_leader() {
     tracing::info!("Commit sequence: {sequence:?}");
 
     assert_eq!(sequence.len(), 1);
-    if let LeaderStatus::Skip(leader, round) = sequence[0] {
+    if let LeaderStatus::DirectSkip(leader, round) | LeaderStatus::IndirectSkip(leader, round) =
+        sequence[0]
+    {
         assert_eq!(leader, leader_1);
         assert_eq!(round, leader_round_1);
     } else {
@@ -260,7 +262,6 @@ fn direct_skip() {
         committee.clone(),
         storage.block_reader().clone(),
         Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);
@@ -268,7 +269,9 @@ fn direct_skip() {
     tracing::info!("Commit sequence: {sequence:?}");
 
     assert_eq!(sequence.len(), 1);
-    if let LeaderStatus::Skip(leader, round) = sequence[0] {
+    if let LeaderStatus::DirectSkip(leader, round) | LeaderStatus::IndirectSkip(leader, round) =
+        sequence[0]
+    {
         assert_eq!(leader, leader_elector.elect_leader(leader_round_1));
         assert_eq!(round, leader_round_1);
     } else {
@@ -362,7 +365,6 @@ fn indirect_commit() {
         committee.clone(),
         storage.block_reader().clone(),
         Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);
@@ -372,7 +374,9 @@ fn indirect_commit() {
 
     let leader_round = 1;
     let leader = leader_elector.elect_leader(leader_round);
-    if let LeaderStatus::Commit(ref block) = sequence[0] {
+    if let LeaderStatus::DirectCommit(ref block) | LeaderStatus::IndirectCommit(ref block) =
+        sequence[0]
+    {
         assert_eq!(block.author(), leader);
     } else {
         panic!("Expected a committed leader")
@@ -434,7 +438,6 @@ fn indirect_skip() {
         committee.clone(),
         storage.block_reader().clone(),
         Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);
@@ -446,7 +449,9 @@ fn indirect_skip() {
     for i in 0..=2 {
         let leader_round = i + 1;
         let leader = leader_elector.elect_leader(leader_round);
-        if let LeaderStatus::Commit(ref block) = sequence[i as usize] {
+        if let LeaderStatus::DirectCommit(ref block) | LeaderStatus::IndirectCommit(ref block) =
+            sequence[i as usize]
+        {
             assert_eq!(block.author(), leader);
         } else {
             panic!("Expected a committed leader")
@@ -454,7 +459,9 @@ fn indirect_skip() {
     }
 
     // Ensure we skip the leader of wave 1 (first pipeline) but commit the others.
-    if let LeaderStatus::Skip(leader, round) = sequence[3] {
+    if let LeaderStatus::DirectSkip(leader, round) | LeaderStatus::IndirectSkip(leader, round) =
+        sequence[3]
+    {
         assert_eq!(leader, leader_elector.elect_leader(leader_round_4));
         assert_eq!(round, leader_round_4);
     } else {
@@ -464,7 +471,9 @@ fn indirect_skip() {
     for i in 4..=6 {
         let leader_round = i + 1;
         let leader = leader_elector.elect_leader(leader_round);
-        if let LeaderStatus::Commit(ref block) = sequence[i as usize] {
+        if let LeaderStatus::DirectCommit(ref block) | LeaderStatus::IndirectCommit(ref block) =
+            sequence[i as usize]
+        {
             assert_eq!(block.author(), leader);
         } else {
             panic!("Expected a committed leader")
@@ -516,7 +525,6 @@ fn undecided() {
         committee.clone(),
         storage.block_reader().clone(),
         Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
-        Metrics::new_for_test(0),
     );
 
     let last_committed = BlockReference::new_test(0, 0);

--- a/crates/dag/src/consensus.rs
+++ b/crates/dag/src/consensus.rs
@@ -75,7 +75,11 @@ impl LeaderStatus {
         match self {
             Self::DirectCommit(block) | Self::IndirectCommit(block) => Some(block),
             Self::DirectSkip(..) | Self::IndirectSkip(..) => None,
-            Self::Undecided(..) => panic!("Decided block is either Commit or Skip"),
+            Self::Undecided(..) => {
+                panic!(
+                    "Decided block must be DirectCommit/IndirectCommit or DirectSkip/IndirectSkip"
+                )
+            }
         }
     }
 }

--- a/crates/dag/src/consensus.rs
+++ b/crates/dag/src/consensus.rs
@@ -35,45 +35,46 @@ pub trait DagConsensus: Send + 'static {
     fn get_leaders(&self, round: RoundNumber) -> Option<impl Iterator<Item = Authority>>;
 }
 
-/// The status of every leader output by the committers. While the core only
-/// cares about committed leaders, providing a richer status allows for easier
-/// debugging, testing, and composition with advanced commit strategies.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+/// The status of every leader output by the committers. While the core only cares about committed
+/// leaders, providing a richer status allows for easier debugging, testing, and composition with
+/// advanced commit strategies.
+#[derive(Debug, Eq, PartialEq)]
 pub enum LeaderStatus {
-    Commit(Data<Block>),
-    Skip(Authority, RoundNumber),
+    DirectCommit(Data<Block>),
+    IndirectCommit(Data<Block>),
+    DirectSkip(Authority, RoundNumber),
+    IndirectSkip(Authority, RoundNumber),
     Undecided(Authority, RoundNumber),
 }
 
 impl LeaderStatus {
     pub fn round(&self) -> RoundNumber {
         match self {
-            Self::Commit(block) => block.round(),
-            Self::Skip(_, round) => *round,
-            Self::Undecided(_, round) => *round,
+            Self::DirectCommit(block) | Self::IndirectCommit(block) => block.round(),
+            Self::DirectSkip(_, round)
+            | Self::IndirectSkip(_, round)
+            | Self::Undecided(_, round) => *round,
         }
     }
 
     pub fn authority(&self) -> Authority {
         match self {
-            Self::Commit(block) => block.author(),
-            Self::Skip(authority, _) => *authority,
-            Self::Undecided(authority, _) => *authority,
+            Self::DirectCommit(block) | Self::IndirectCommit(block) => block.author(),
+            Self::DirectSkip(authority, _)
+            | Self::IndirectSkip(authority, _)
+            | Self::Undecided(authority, _) => *authority,
         }
     }
 
+    /// True for every variant except `Undecided`.
     pub fn is_decided(&self) -> bool {
-        match self {
-            Self::Commit(_) => true,
-            Self::Skip(_, _) => true,
-            Self::Undecided(_, _) => false,
-        }
+        !matches!(self, Self::Undecided(..))
     }
 
     pub fn into_decided_block(self) -> Option<Data<Block>> {
         match self {
-            Self::Commit(block) => Some(block),
-            Self::Skip(..) => None,
+            Self::DirectCommit(block) | Self::IndirectCommit(block) => Some(block),
+            Self::DirectSkip(..) | Self::IndirectSkip(..) => None,
             Self::Undecided(..) => panic!("Decided block is either Commit or Skip"),
         }
     }
@@ -94,13 +95,11 @@ impl Ord for LeaderStatus {
 impl fmt::Display for LeaderStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Commit(block) => write!(f, "Commit({})", block.reference()),
-            Self::Skip(a, r) => {
-                write!(f, "Skip({})", a.with_round(*r))
-            }
-            Self::Undecided(a, r) => {
-                write!(f, "Undecided({})", a.with_round(*r))
-            }
+            Self::DirectCommit(block) => write!(f, "DirectCommit({})", block.reference()),
+            Self::IndirectCommit(block) => write!(f, "IndirectCommit({})", block.reference()),
+            Self::DirectSkip(a, r) => write!(f, "DirectSkip({})", a.with_round(*r)),
+            Self::IndirectSkip(a, r) => write!(f, "IndirectSkip({})", a.with_round(*r)),
+            Self::Undecided(a, r) => write!(f, "Undecided({})", a.with_round(*r)),
         }
     }
 }

--- a/crates/dag/src/core.rs
+++ b/crates/dag/src/core.rs
@@ -294,9 +294,11 @@ impl<C: Ctx, D: DagConsensus> Core<C, D> {
     }
 
     pub fn try_commit(&mut self) -> Vec<Data<Block>> {
+        let metrics = &self.metrics;
         let sequence: Vec<_> = self
             .committer
             .try_commit(self.last_commit_leader)
+            .inspect(|leader| metrics.inc_decided_leaders(leader))
             .filter_map(|leader| leader.into_decided_block())
             .collect();
 

--- a/crates/dag/src/metrics.rs
+++ b/crates/dag/src/metrics.rs
@@ -18,13 +18,20 @@ use tokio::time::Instant;
 pub use self::aggregate::AggregateMetrics;
 pub(crate) use self::names::WORKLOAD_SHARED;
 pub use self::names::{
-    BENCHMARK_DURATION, BLOCK_SYNC_REQUESTS_SENT, DecisionType, LABEL_AUTHORITY, LABEL_WORKLOAD,
-    LATENCY_S, LATENCY_SQUARED_S, LEADER_TIMEOUT_TOTAL, SyncRequestFulfilled,
+    BENCHMARK_DURATION, BLOCK_SYNC_REQUESTS_SENT, LABEL_AUTHORITY, LABEL_WORKLOAD, LATENCY_S,
+    LATENCY_SQUARED_S, LEADER_TIMEOUT_TOTAL, SyncRequestFulfilled,
 };
 pub use self::snapshot::MetricsSnapshot;
 pub use self::timers::{OwnedUtilizationTimer, UtilizationTimer};
-use self::{coarse::CoarseMetrics, precise::PreciseMetrics};
-use crate::authority::Authority;
+use self::{
+    coarse::CoarseMetrics,
+    names::{
+        COMMIT_TYPE_DIRECT_COMMIT, COMMIT_TYPE_DIRECT_SKIP, COMMIT_TYPE_INDIRECT_COMMIT,
+        COMMIT_TYPE_INDIRECT_SKIP,
+    },
+    precise::PreciseMetrics,
+};
+use crate::{authority::Authority, consensus::LeaderStatus};
 
 pub struct Metrics {
     coarse: CoarseMetrics,
@@ -144,11 +151,21 @@ impl Metrics {
             .observe(value);
     }
 
-    pub fn inc_committed_leaders(&self, authority: Authority, decision: DecisionType) {
-        let label = authority.to_string();
+    /// Record a decided leader on `committed_leaders_total`. Silent no-op on
+    /// `LeaderStatus::Undecided` — only decided statuses (commit or skip, direct or indirect)
+    /// produce a metric increment.
+    pub fn inc_decided_leaders(&self, status: &LeaderStatus) {
+        let label = match status {
+            LeaderStatus::DirectCommit(_) => COMMIT_TYPE_DIRECT_COMMIT,
+            LeaderStatus::IndirectCommit(_) => COMMIT_TYPE_INDIRECT_COMMIT,
+            LeaderStatus::DirectSkip(..) => COMMIT_TYPE_DIRECT_SKIP,
+            LeaderStatus::IndirectSkip(..) => COMMIT_TYPE_INDIRECT_SKIP,
+            LeaderStatus::Undecided(..) => return,
+        };
+        let authority = status.authority().to_string();
         self.coarse
             .committed_leaders_total
-            .with_label_values(&[&label, decision.as_label()])
+            .with_label_values(&[&authority, label])
             .inc();
     }
 
@@ -253,7 +270,8 @@ struct NetworkAddressTable {
 mod test {
     use std::time::Duration;
 
-    use super::{Authority, DecisionType, Metrics};
+    use super::{Authority, Metrics};
+    use crate::consensus::LeaderStatus;
 
     #[test]
     fn new_for_test_collect_roundtrip() {
@@ -280,29 +298,23 @@ mod test {
         let a = Authority::from(0_usize);
         let b = Authority::from(1_usize);
         let metrics = Metrics::new_for_test(4);
-        metrics.inc_committed_leaders(a, DecisionType::DirectCommit);
-        metrics.inc_committed_leaders(a, DecisionType::DirectCommit);
-        metrics.inc_committed_leaders(b, DecisionType::IndirectSkip);
+        metrics.inc_decided_leaders(&LeaderStatus::DirectSkip(a, 1));
+        metrics.inc_decided_leaders(&LeaderStatus::DirectSkip(a, 2));
+        metrics.inc_decided_leaders(&LeaderStatus::IndirectSkip(b, 1));
         metrics.set_missing_blocks(a, 3);
         metrics.inc_block_sync_requests_sent(a);
         let snapshot = metrics.collect();
         assert_eq!(
             snapshot.metric(
                 "committed_leaders_total",
-                &[
-                    ("authority", "A"),
-                    ("commit_type", DecisionType::DirectCommit.as_label()),
-                ]
+                &[("authority", "A"), ("commit_type", "direct-skip")]
             ),
             2.0
         );
         assert_eq!(
             snapshot.metric(
                 "committed_leaders_total",
-                &[
-                    ("authority", "B"),
-                    ("commit_type", DecisionType::IndirectSkip.as_label()),
-                ]
+                &[("authority", "B"), ("commit_type", "indirect-skip")]
             ),
             1.0
         );

--- a/crates/dag/src/metrics.rs
+++ b/crates/dag/src/metrics.rs
@@ -272,6 +272,10 @@ mod test {
 
     use super::{Authority, Metrics};
     use crate::consensus::LeaderStatus;
+    use crate::metrics::names::{
+        COMMIT_TYPE_DIRECT_SKIP, COMMIT_TYPE_INDIRECT_SKIP, COMMITTED_LEADERS_TOTAL,
+        LABEL_AUTHORITY, LABEL_COMMIT_TYPE,
+    };
 
     #[test]
     fn new_for_test_collect_roundtrip() {
@@ -304,23 +308,34 @@ mod test {
         metrics.set_missing_blocks(a, 3);
         metrics.inc_block_sync_requests_sent(a);
         let snapshot = metrics.collect();
+        let authority_a = a.to_string();
+        let authority_b = b.to_string();
         assert_eq!(
             snapshot.metric(
-                "committed_leaders_total",
-                &[("authority", "A"), ("commit_type", "direct-skip")]
+                COMMITTED_LEADERS_TOTAL,
+                &[
+                    (LABEL_AUTHORITY, &authority_a),
+                    (LABEL_COMMIT_TYPE, COMMIT_TYPE_DIRECT_SKIP),
+                ]
             ),
             2.0
         );
         assert_eq!(
             snapshot.metric(
-                "committed_leaders_total",
-                &[("authority", "B"), ("commit_type", "indirect-skip")]
+                COMMITTED_LEADERS_TOTAL,
+                &[
+                    (LABEL_AUTHORITY, &authority_b),
+                    (LABEL_COMMIT_TYPE, COMMIT_TYPE_INDIRECT_SKIP),
+                ]
             ),
             1.0
         );
         assert_eq!(snapshot.missing_blocks(a), 3);
         assert_eq!(
-            snapshot.metric("block_sync_requests_sent", &[("authority", "A")]),
+            snapshot.metric(
+                "block_sync_requests_sent",
+                &[(LABEL_AUTHORITY, &authority_a)]
+            ),
             1.0
         );
     }

--- a/crates/dag/src/metrics/aggregate.rs
+++ b/crates/dag/src/metrics/aggregate.rs
@@ -71,9 +71,10 @@ impl<'a> AggregateMetrics<'a> {
             .any(|(i, snapshot)| snapshot.missing_blocks(Authority::from(i)) > 0)
     }
 
-    /// Total committed leaders per second. Each replica contributes its observed
-    /// committed-leader sequence length (all authorities, commits only). Returns `None`
-    /// when `duration` is zero or nothing committed anywhere.
+    /// Committed leaders per second, averaged across replicas. Each replica contributes
+    /// its observed total committed-leader sequence length across all authorities
+    /// (commits only). Returns `None` when `duration` is zero or nothing committed
+    /// anywhere.
     pub fn leader_commits_per_second(&self, duration: Duration) -> Option<f64> {
         if duration.is_zero() {
             return None;

--- a/crates/dag/src/metrics/names.rs
+++ b/crates/dag/src/metrics/names.rs
@@ -6,8 +6,6 @@
 // `AggregateMetrics`) both reference these constants so a rename is a one-line diff and typos
 // become compile errors.
 
-use crate::consensus::LeaderStatus;
-
 // Metric names.
 pub const BENCHMARK_DURATION: &str = "benchmark_duration";
 pub const LATENCY_S: &str = "latency_s";
@@ -42,57 +40,11 @@ pub const LABEL_PROC: &str = "proc";
 // Well-known label values (extracted when used in more than one place).
 pub const WORKLOAD_SHARED: &str = "shared";
 
-/// Canonical decision outcome for a leader slot, as recorded in the `commit_type` Prometheus
-/// label on `committed_leaders_total`. Producers classify a `(LeaderStatus, direct_decide)` pair
-/// into one of these four variants; consumers compare against `DecisionType::as_label()` when
-/// reading.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum DecisionType {
-    DirectCommit,
-    IndirectCommit,
-    DirectSkip,
-    IndirectSkip,
-}
-
-impl DecisionType {
-    /// Canonical string used in the Prometheus `commit_type` label.
-    pub fn as_label(&self) -> &'static str {
-        match self {
-            Self::DirectCommit => "direct-commit",
-            Self::IndirectCommit => "indirect-commit",
-            Self::DirectSkip => "direct-skip",
-            Self::IndirectSkip => "indirect-skip",
-        }
-    }
-
-    /// Inverse of [`Self::as_label`]. Returns `None` for unknown label values.
-    pub fn from_label(label: &str) -> Option<Self> {
-        match label {
-            "direct-commit" => Some(Self::DirectCommit),
-            "indirect-commit" => Some(Self::IndirectCommit),
-            "direct-skip" => Some(Self::DirectSkip),
-            "indirect-skip" => Some(Self::IndirectSkip),
-            _ => None,
-        }
-    }
-
-    /// True when this decision committed the leader (as opposed to skipping it).
-    pub fn is_committed(&self) -> bool {
-        matches!(self, Self::DirectCommit | Self::IndirectCommit)
-    }
-
-    /// Classify a `(LeaderStatus, direct_decide)` pair. Returns `None` for `Undecided` — it's not
-    /// a decision outcome, so callers should skip metric emission entirely in that case.
-    pub fn classify(leader: &LeaderStatus, direct: bool) -> Option<Self> {
-        match (leader, direct) {
-            (LeaderStatus::Commit(..), true) => Some(Self::DirectCommit),
-            (LeaderStatus::Commit(..), false) => Some(Self::IndirectCommit),
-            (LeaderStatus::Skip(..), true) => Some(Self::DirectSkip),
-            (LeaderStatus::Skip(..), false) => Some(Self::IndirectSkip),
-            (LeaderStatus::Undecided(..), _) => None,
-        }
-    }
-}
+// Values for the `commit_type` label on `committed_leaders_total`.
+pub const COMMIT_TYPE_DIRECT_COMMIT: &str = "direct-commit";
+pub const COMMIT_TYPE_INDIRECT_COMMIT: &str = "indirect-commit";
+pub const COMMIT_TYPE_DIRECT_SKIP: &str = "direct-skip";
+pub const COMMIT_TYPE_INDIRECT_SKIP: &str = "indirect-skip";
 
 /// Outcome of a block sync request from a peer, recorded in the `fulfilled` Prometheus label on
 /// `block_sync_requests_received`. `Found` = we had the block and served it; `Missing` = we did

--- a/crates/dag/src/metrics/snapshot.rs
+++ b/crates/dag/src/metrics/snapshot.rs
@@ -281,6 +281,8 @@ mod test {
         // Drives `committed_leaders_total` directly so the test doesn't need a `Data<Block>` to
         // construct `LeaderStatus::DirectCommit`. Label values here must match the wire strings
         // that `Metrics::inc_decided_leaders` writes.
+        let authority = Authority::from(0_usize);
+        let authority_label = authority.to_string();
         let registry = Registry::new();
         let counter = register_int_counter_vec_with_registry!(
             "committed_leaders_total",
@@ -290,19 +292,19 @@ mod test {
         )
         .unwrap();
         counter
-            .with_label_values(&["A", COMMIT_TYPE_DIRECT_COMMIT])
+            .with_label_values(&[&authority_label, COMMIT_TYPE_DIRECT_COMMIT])
             .inc();
         counter
-            .with_label_values(&["A", COMMIT_TYPE_INDIRECT_COMMIT])
+            .with_label_values(&[&authority_label, COMMIT_TYPE_INDIRECT_COMMIT])
             .inc();
         counter
-            .with_label_values(&["A", COMMIT_TYPE_DIRECT_SKIP])
+            .with_label_values(&[&authority_label, COMMIT_TYPE_DIRECT_SKIP])
             .inc();
         counter
-            .with_label_values(&["A", COMMIT_TYPE_INDIRECT_SKIP])
+            .with_label_values(&[&authority_label, COMMIT_TYPE_INDIRECT_SKIP])
             .inc();
         let snapshot = collect_snapshot(&registry);
-        assert_eq!(snapshot.committed_leaders(Authority::from(0_usize)), 2);
+        assert_eq!(snapshot.committed_leaders(authority), 2);
     }
 
     #[test]

--- a/crates/dag/src/metrics/snapshot.rs
+++ b/crates/dag/src/metrics/snapshot.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 use prometheus::proto::MetricFamily;
 
 use super::names::{
-    COMMITTED_LEADERS_TOTAL, DecisionType, LABEL_AUTHORITY, LABEL_COMMIT_TYPE, LABEL_WORKLOAD,
-    LATENCY_S, MISSING_BLOCKS, WORKLOAD_SHARED,
+    COMMIT_TYPE_DIRECT_COMMIT, COMMIT_TYPE_INDIRECT_COMMIT, COMMITTED_LEADERS_TOTAL,
+    LABEL_AUTHORITY, LABEL_COMMIT_TYPE, LABEL_WORKLOAD, LATENCY_S, MISSING_BLOCKS, WORKLOAD_SHARED,
 };
 use crate::authority::Authority;
 
@@ -67,30 +67,26 @@ impl MetricsSnapshot {
         self.metric(MISSING_BLOCKS, &[(LABEL_AUTHORITY, &label)]) as i64
     }
 
-    /// Total leaders *committed* by `authority` — the commit rows of `committed_leaders_total`,
-    /// as identified by [`DecisionType::is_committed`]. Skipped leaders are excluded.
+    /// Total leaders *committed* by `authority` — the commit rows of `committed_leaders_total`
+    /// (the `direct-commit` and `indirect-commit` `commit_type` labels). Skipped leaders are
+    /// excluded.
     pub fn committed_leaders(&self, authority: Authority) -> u64 {
         let label = authority.to_string();
-        let mut total = 0.0;
-        for family in &self.families {
-            if family.get_name() != COMMITTED_LEADERS_TOTAL {
-                continue;
-            }
-            for metric in family.get_metric() {
-                let labels = metric.get_label();
-                let authority_matches = labels
-                    .iter()
-                    .any(|l| l.get_name() == LABEL_AUTHORITY && l.get_value() == label);
-                let is_commit = labels.iter().any(|l| {
-                    l.get_name() == LABEL_COMMIT_TYPE
-                        && DecisionType::from_label(l.get_value()).is_some_and(|d| d.is_committed())
-                });
-                if authority_matches && is_commit && metric.has_counter() {
-                    total += metric.get_counter().get_value();
-                }
-            }
-        }
-        total as u64
+        let direct = self.metric(
+            COMMITTED_LEADERS_TOTAL,
+            &[
+                (LABEL_AUTHORITY, &label),
+                (LABEL_COMMIT_TYPE, COMMIT_TYPE_DIRECT_COMMIT),
+            ],
+        );
+        let indirect = self.metric(
+            COMMITTED_LEADERS_TOTAL,
+            &[
+                (LABEL_AUTHORITY, &label),
+                (LABEL_COMMIT_TYPE, COMMIT_TYPE_INDIRECT_COMMIT),
+            ],
+        );
+        (direct + indirect) as u64
     }
 
     /// Committed leaders per second observed by this replica. Returns `None` when `duration` is
@@ -107,8 +103,8 @@ impl MetricsSnapshot {
         (count > 0).then(|| count as f64 / duration.as_secs_f64())
     }
 
-    /// Total committed leaders observed by by this replica. Skipped leaders are excluded,
-    /// same rule as [`committed_leaders`].
+    /// Total committed leaders observed by this replica. Skipped leaders are excluded, same
+    /// rule as [`committed_leaders`].
     pub fn total_committed_leaders(&self) -> u64 {
         let mut total = 0.0;
         for family in &self.families {
@@ -118,7 +114,10 @@ impl MetricsSnapshot {
             for metric in family.get_metric() {
                 let is_commit = metric.get_label().iter().any(|l| {
                     l.get_name() == LABEL_COMMIT_TYPE
-                        && DecisionType::from_label(l.get_value()).is_some_and(|d| d.is_committed())
+                        && matches!(
+                            l.get_value(),
+                            COMMIT_TYPE_DIRECT_COMMIT | COMMIT_TYPE_INDIRECT_COMMIT,
+                        )
                 });
                 if is_commit && metric.has_counter() {
                     total += metric.get_counter().get_value();
@@ -219,8 +218,8 @@ impl MetricsSnapshot {
 
 #[cfg(test)]
 mod test {
-    use super::{DecisionType, MetricsSnapshot};
-    use crate::{authority::Authority, metrics::Metrics};
+    use super::MetricsSnapshot;
+    use crate::authority::Authority;
     use prometheus::{
         Registry, register_histogram_with_registry, register_int_counter_vec_with_registry,
         register_int_counter_with_registry, register_int_gauge_with_registry,
@@ -272,14 +271,23 @@ mod test {
 
     #[test]
     fn committed_leaders_excludes_skips() {
-        let metrics = Metrics::new_for_test(4);
-        let a = Authority::from(0_usize);
-        metrics.inc_committed_leaders(a, DecisionType::DirectCommit);
-        metrics.inc_committed_leaders(a, DecisionType::IndirectCommit);
-        metrics.inc_committed_leaders(a, DecisionType::DirectSkip);
-        metrics.inc_committed_leaders(a, DecisionType::IndirectSkip);
-        let snapshot = metrics.collect();
-        assert_eq!(snapshot.committed_leaders(a), 2);
+        // Drives `committed_leaders_total` directly so the test doesn't need a `Data<Block>` to
+        // construct `LeaderStatus::DirectCommit`. Label values here must match the wire strings
+        // that `Metrics::inc_decided_leaders` writes.
+        let registry = Registry::new();
+        let counter = register_int_counter_vec_with_registry!(
+            "committed_leaders_total",
+            "help",
+            &["authority", "commit_type"],
+            registry
+        )
+        .unwrap();
+        counter.with_label_values(&["A", "direct-commit"]).inc();
+        counter.with_label_values(&["A", "indirect-commit"]).inc();
+        counter.with_label_values(&["A", "direct-skip"]).inc();
+        counter.with_label_values(&["A", "indirect-skip"]).inc();
+        let snapshot = collect_snapshot(&registry);
+        assert_eq!(snapshot.committed_leaders(Authority::from(0_usize)), 2);
     }
 
     #[test]

--- a/crates/dag/src/metrics/snapshot.rs
+++ b/crates/dag/src/metrics/snapshot.rs
@@ -176,11 +176,14 @@ impl MetricsSnapshot {
                     prev_bound = if upper.is_finite() { upper } else { prev_bound };
                     prev_count = count;
                 }
-                // Unreachable: the `+Inf` bucket's cumulative_count always equals total, so the
-                // `count >= target` branch must fire before falling out of the loop.
-                unreachable!(
+                // The `+Inf` bucket's cumulative_count should always equal total, so the
+                // `count >= target` branch must fire before falling out of the loop. If we
+                // still get here the metric data is malformed — log and treat as unavailable
+                // rather than panic in the reporting path.
+                tracing::error!(
                     "malformed histogram {name:?}: cumulative_count never reaches sample_count"
                 );
+                return None;
             }
         }
         None
@@ -220,6 +223,10 @@ impl MetricsSnapshot {
 mod test {
     use super::MetricsSnapshot;
     use crate::authority::Authority;
+    use crate::metrics::names::{
+        COMMIT_TYPE_DIRECT_COMMIT, COMMIT_TYPE_DIRECT_SKIP, COMMIT_TYPE_INDIRECT_COMMIT,
+        COMMIT_TYPE_INDIRECT_SKIP,
+    };
     use prometheus::{
         Registry, register_histogram_with_registry, register_int_counter_vec_with_registry,
         register_int_counter_with_registry, register_int_gauge_with_registry,
@@ -282,10 +289,18 @@ mod test {
             registry
         )
         .unwrap();
-        counter.with_label_values(&["A", "direct-commit"]).inc();
-        counter.with_label_values(&["A", "indirect-commit"]).inc();
-        counter.with_label_values(&["A", "direct-skip"]).inc();
-        counter.with_label_values(&["A", "indirect-skip"]).inc();
+        counter
+            .with_label_values(&["A", COMMIT_TYPE_DIRECT_COMMIT])
+            .inc();
+        counter
+            .with_label_values(&["A", COMMIT_TYPE_INDIRECT_COMMIT])
+            .inc();
+        counter
+            .with_label_values(&["A", COMMIT_TYPE_DIRECT_SKIP])
+            .inc();
+        counter
+            .with_label_values(&["A", COMMIT_TYPE_INDIRECT_SKIP])
+            .inc();
         let snapshot = collect_snapshot(&registry);
         assert_eq!(snapshot.committed_leaders(Authority::from(0_usize)), 2);
     }

--- a/crates/replica/src/replica.rs
+++ b/crates/replica/src/replica.rs
@@ -113,12 +113,7 @@ impl Replica {
             .unwrap_or_else(|| protocol.default_round_timeout());
         let enable_synchronizer = parameters.dag.enable_synchronizer;
         let fsync = parameters.dag.fsync;
-        let committer = Committer::new(
-            committee.clone(),
-            storage.block_reader().clone(),
-            protocol,
-            metrics.clone(),
-        );
+        let committer = Committer::new(committee.clone(), storage.block_reader().clone(), protocol);
         let core = Core::open(
             block_handler,
             authority,


### PR DESCRIPTION
## Summary

- Fix `committed_leaders_total` ~2x inflation: emission moved from inside `Committer::try_commit`'s idempotent re-evaluation loop into `Core::try_commit` via `.inspect`, so each newly-yielded `LeaderStatus` fires exactly once.
- Unify `LeaderStatus` with `DecisionType`: enum now has five variants (`DirectCommit`, `IndirectCommit`, `DirectSkip`, `IndirectSkip`, `Undecided`); the decision path travels in the status. `DecisionType` is replaced by four `COMMIT_TYPE_*` wire-string consts.
- Plus two small feature commits already on the branch: p50/p90 latency stats, and a `committed_leaders` snapshot helper.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 31 consensus tests, 41 dag tests pass
- [x] `cargo fmt --check` + pre-commit hooks
- [x] Simulator sanity check: `commits/s` now matches `committed / duration` (was 2x before)
- [ ] CI green

## Known caveat (follow-up)

Trailing *skips* can still be re-yielded: if `try_commit` returns `[Commit(A), Skip(B)]`, `last_commit_leader` advances only to `A`, so `B` is re-yielded on the next call. Commit rows (what the CLI reads) are exact; skip rows can inflate slightly. Strictly better than before (which inflated everything), but not fully resolved. Follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)