### PR TITLE
feat: validator letters + p50/p90 latency in sim table

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -27,9 +27,9 @@ pub struct Args {
 #[derive(Parser)]
 pub enum Command {
     /// Generate test genesis files: one public replica config (identities, stakes, and parameters)
-    /// plus a private config per validator (keys and storage paths). Keys are written in plaintext.
+    /// plus a private config per replica (keys and storage paths). Keys are written in plaintext.
     TestGenesis {
-        /// IP addresses of all validators.
+        /// IP addresses of all replicas.
         #[arg(long, value_name = "ADDR", value_delimiter = ' ', num_args(3..))]
         ips: Vec<IpAddr>,
         /// Working directory where files will be generated.
@@ -68,12 +68,12 @@ pub enum Command {
         dump_config: bool,
     },
 
-    /// Deploy a local testbed of validators on localhost.
+    /// Deploy a local testbed of replicas on localhost.
     ///
-    /// Starts all validators in a single process with default keys and committee configuration.
+    /// Starts all replicas in a single process with default keys and committee configuration.
     /// Useful for local testing.
     LocalTestbed {
-        /// Number of validators in the testbed.
+        /// Number of replicas in the testbed.
         #[arg(long, value_name = "INT", default_value_t = 4)]
         committee_size: usize,
         /// Path to custom replica parameters (YAML). Uses defaults if omitted.

--- a/crates/cli/src/commands/genesis.rs
+++ b/crates/cli/src/commands/genesis.rs
@@ -26,7 +26,7 @@ pub fn test_genesis(
     .setup()?;
 
     let committee_size = ips.len();
-    tracing::info!("Generating test genesis for {committee_size} validators");
+    tracing::info!("Generating test genesis for {committee_size} replicas");
 
     // Create the output directory for all genesis files.
     fs::create_dir_all(&working_directory).wrap_err(format!(
@@ -46,7 +46,7 @@ pub fn test_genesis(
         }
     };
 
-    // Generate the public replica config: parameters + per-validator
+    // Generate the public replica config: parameters + per-replica
     // identities (public key, stake, network/metrics addresses). The
     // committee used by consensus is derived from this file at runtime.
     let public_config = PublicReplicaConfig::new_for_benchmarks(ips).with_parameters(parameters);
@@ -54,13 +54,13 @@ pub fn test_genesis(
     public_config.print(&public_config_path)?;
     tracing::info!("Wrote {}", public_config_path.display());
 
-    // Generate one private config per validator (keys, storage path).
+    // Generate one private config per replica (keys, storage path).
     let private_configs =
         PrivateReplicaConfig::new_for_benchmarks(&working_directory, committee_size);
     for (i, private_config) in private_configs.into_iter().enumerate() {
         let authority = Authority::from(i);
         fs::create_dir_all(&private_config.storage_path).wrap_err(format!(
-            "Failed to create storage directory for validator {authority}"
+            "Failed to create storage directory for replica {authority}"
         ))?;
         let path = working_directory.join(PrivateReplicaConfig::default_filename(authority));
         private_config.print(&path)?;
@@ -68,7 +68,7 @@ pub fn test_genesis(
     }
 
     tracing::info!(
-        "Test genesis for {committee_size} validators ready in '{}'",
+        "Test genesis for {committee_size} replicas ready in '{}'",
         working_directory.display()
     );
     Ok(())

--- a/crates/cli/src/commands/simulate.rs
+++ b/crates/cli/src/commands/simulate.rs
@@ -78,7 +78,7 @@ pub async fn simulate(
 pub enum Outcome {
     /// Safety held and at least one leader was committed somewhere.
     Pass,
-    /// Safety held but no validator committed a single leader.
+    /// Safety held but no replica committed a single leader.
     /// Expected under unrecoverable partitions (star, symmetric split).
     NoProgress,
     /// Safety violated: commit histories disagree.
@@ -108,9 +108,9 @@ impl Outcome {
 
     pub fn message(&self) -> &'static str {
         match self {
-            Self::Pass => "Commits consistent across all validators",
+            Self::Pass => "Commits consistent across all replicas",
             Self::NoProgress => "Safe but no leader was committed",
-            Self::Diverged => "Commits DIVERGED across validators",
+            Self::Diverged => "Commits DIVERGED across replicas",
         }
     }
 

--- a/crates/cli/src/commands/testbed.rs
+++ b/crates/cli/src/commands/testbed.rs
@@ -68,7 +68,7 @@ pub async fn local_testbed(
     let public_config =
         PublicReplicaConfig::new_for_benchmarks(ips).with_parameters(replica_parameters);
 
-    // Prepare a clean working directory for the validators' WAL files.
+    // Prepare a clean working directory for the replicas' WAL files.
     let working_dir = PathBuf::from("local-testbed");
     match fs::remove_dir_all(&working_dir) {
         Ok(_) => {}
@@ -88,10 +88,10 @@ pub async fn local_testbed(
         ))?;
     }
 
-    tracing::info!("Starting local testbed with {committee_size} validators");
+    tracing::info!("Starting local testbed with {committee_size} replicas");
 
-    // Spin up each validator: run the replica, start its load generator, expose its metrics.
-    // Each validator gets its own registry and metrics server on a distinct port.
+    // Spin up each replica: run it, start its load generator, expose its metrics.
+    // Each replica gets its own registry and metrics server on a distinct port.
     let mut handles = Vec::with_capacity(committee_size);
     let mut metrics_servers = Vec::with_capacity(committee_size);
     let mut load_generators = Vec::with_capacity(committee_size);
@@ -116,7 +116,7 @@ pub async fn local_testbed(
         handles.push(handle);
     }
 
-    tracing::info!("All {committee_size} validators running. Press Ctrl-C to stop.");
+    tracing::info!("All {committee_size} replicas running. Press Ctrl-C to stop.");
 
     // Block until the user interrupts, then tear everything down.
     tokio::signal::ctrl_c()

--- a/crates/cli/src/reporter.rs
+++ b/crates/cli/src/reporter.rs
@@ -11,7 +11,7 @@ use simulator::{SimulationConfig, SimulationResults, SimulationRunner};
 use crate::{
     banner::BannerPrinter,
     commands::simulate::Outcome,
-    table::{self, ConfigRow, SuiteRow, ValidatorRow},
+    table::{self, ConfigRow, ReplicaRow, SuiteRow},
 };
 
 pub const BLUE_FOREGROUND: &str = "\x1b[34m";
@@ -72,7 +72,7 @@ impl Reporter {
         println!("{}", table::render(ConfigRow::for_config(config)));
     }
 
-    /// Execute one simulation: spinner → run → badge → per-validator
+    /// Execute one simulation: spinner → run → badge → per-replica
     /// report. Returns the outcome and the suite-level row so the
     /// caller can track suite-wide aggregates.
     pub async fn run(&self, config: SimulationConfig) -> Result<(Outcome, SuiteRow)> {
@@ -103,10 +103,10 @@ impl Reporter {
     fn render_run(&self, results: &SimulationResults, duration_secs: u64, outcome: Outcome) {
         self.run_badge(outcome);
 
-        let rows = ValidatorRow::for_results(results, duration_secs);
+        let rows = ReplicaRow::for_results(results, duration_secs);
 
         // Collapse to a single-line summary in the happy path when every
-        // validator committed the same leaders and nothing is noteworthy.
+        // replica committed the same leaders and nothing is noteworthy.
         let aggregate = AggregateMetrics::new(&results.metrics);
         if outcome != Outcome::Diverged
             && results.uniform_commits()
@@ -130,7 +130,7 @@ impl Reporter {
             return;
         }
 
-        self.validators_table(rows);
+        self.replicas_table(rows);
     }
 
     fn start_spinner(&self) -> Option<ProgressBar> {
@@ -174,7 +174,7 @@ impl Reporter {
         }
     }
 
-    fn validators_table(&self, rows: Vec<ValidatorRow>) {
+    fn replicas_table(&self, rows: Vec<ReplicaRow>) {
         println!("{}", table::render(rows));
     }
 

--- a/crates/cli/src/table.rs
+++ b/crates/cli/src/table.rs
@@ -65,7 +65,7 @@ pub struct ValidatorRow {
     #[tabled(rename = "leader timeouts")]
     leader_timeouts: u64,
     #[tabled(rename = "missing blocks")]
-    pub missing_blocks: String,
+    pub missing_blocks: i64,
     #[tabled(rename = "sync requests sent")]
     sync_requests_sent: u64,
 }
@@ -118,7 +118,7 @@ impl ValidatorRow {
             p50_latency,
             p90_latency,
             leader_timeouts,
-            missing_blocks: missing_blocks.to_string(),
+            missing_blocks,
             sync_requests_sent,
         }
     }

--- a/crates/cli/src/table.rs
+++ b/crates/cli/src/table.rs
@@ -53,13 +53,15 @@ impl ConfigRow {
 #[derive(Tabled)]
 pub struct ValidatorRow {
     #[tabled(rename = "validator")]
-    validator: usize,
+    validator: String,
     #[tabled(rename = "committed leaders")]
     committed_leaders: usize,
     #[tabled(rename = "commits/s")]
     commits_per_sec: String,
-    #[tabled(rename = "mean latency")]
-    mean_latency: String,
+    #[tabled(rename = "p50 latency")]
+    p50_latency: String,
+    #[tabled(rename = "p90 latency")]
+    p90_latency: String,
     #[tabled(rename = "leader timeouts")]
     leader_timeouts: u64,
     #[tabled(rename = "missing blocks")]
@@ -96,20 +98,25 @@ impl ValidatorRow {
         } else {
             format!("{:.1}", committed_leaders as f64 / duration_secs as f64)
         };
-        let mean_latency = metrics
-            .histogram_mean(LATENCY_S, &[(LABEL_WORKLOAD, "shared")])
-            .map(|seconds| format!("{:.0} ms", seconds * 1000.0))
-            .unwrap_or_else(|| "—".into());
+        let latency_ms = |p: f64| {
+            metrics
+                .histogram_percentile(LATENCY_S, &[(LABEL_WORKLOAD, "shared")], p)
+                .map(|seconds| format!("{:.0} ms", seconds * 1000.0))
+                .unwrap_or_else(|| "—".into())
+        };
+        let p50_latency = latency_ms(0.5);
+        let p90_latency = latency_ms(0.9);
         let leader_timeouts = metrics.metric(LEADER_TIMEOUT_TOTAL, &[]) as u64;
         let missing_blocks = metrics.missing_blocks(authority);
         let sync_requests_sent =
             metrics.metric(BLOCK_SYNC_REQUESTS_SENT, &[(LABEL_AUTHORITY, &label)]) as u64;
 
         Self {
-            validator: authority.index(),
+            validator: label,
             committed_leaders,
             commits_per_sec,
-            mean_latency,
+            p50_latency,
+            p90_latency,
             leader_timeouts,
             missing_blocks: missing_blocks.to_string(),
             sync_requests_sent,

--- a/crates/cli/src/table.rs
+++ b/crates/cli/src/table.rs
@@ -51,9 +51,9 @@ impl ConfigRow {
 }
 
 #[derive(Tabled)]
-pub struct ValidatorRow {
-    #[tabled(rename = "validator")]
-    validator: Authority,
+pub struct ReplicaRow {
+    #[tabled(rename = "replica")]
+    replica: Authority,
     #[tabled(rename = "committed leaders")]
     committed_leaders: usize,
     #[tabled(rename = "commits/s")]
@@ -70,7 +70,7 @@ pub struct ValidatorRow {
     sync_requests_sent: u64,
 }
 
-impl ValidatorRow {
+impl ReplicaRow {
     pub fn for_results(results: &SimulationResults, duration_secs: u64) -> Vec<Self> {
         results
             .committed_leaders
@@ -112,7 +112,7 @@ impl ValidatorRow {
             metrics.metric(BLOCK_SYNC_REQUESTS_SENT, &[(LABEL_AUTHORITY, &label)]) as u64;
 
         Self {
-            validator: authority,
+            replica: authority,
             committed_leaders,
             commits_per_sec,
             p50_latency,

--- a/crates/cli/src/table.rs
+++ b/crates/cli/src/table.rs
@@ -53,7 +53,7 @@ impl ConfigRow {
 #[derive(Tabled)]
 pub struct ValidatorRow {
     #[tabled(rename = "validator")]
-    validator: String,
+    validator: Authority,
     #[tabled(rename = "committed leaders")]
     committed_leaders: usize,
     #[tabled(rename = "commits/s")]
@@ -112,7 +112,7 @@ impl ValidatorRow {
             metrics.metric(BLOCK_SYNC_REQUESTS_SENT, &[(LABEL_AUTHORITY, &label)]) as u64;
 
         Self {
-            validator: label,
+            validator: authority,
             committed_leaders,
             commits_per_sec,
             p50_latency,

--- a/crates/consensus/src/tests/base_committer_tests.rs
+++ b/crates/consensus/src/tests/base_committer_tests.rs
@@ -357,7 +357,7 @@ fn indirect_commit() {
         .filter(|x| x.authority != leader_elector.elect_leader(leader_round_1))
         .collect();
 
-    // Only 2f+1 validators vote for the 1st leader.
+    // Only 2f+1 replicas vote for the 1st leader.
     let connections_with_leader_1 = committee
         .authorities()
         .take(strong_quorum as usize)
@@ -374,7 +374,7 @@ fn indirect_commit() {
     let references_without_votes_for_leader_1 =
         build_dag_layer(connections_without_leader_1, &mut storage);
 
-    // Only f+1 validators certify the 1st leader.
+    // Only f+1 replicas certify the 1st leader.
     let mut references_3 = Vec::new();
 
     let connections_with_votes_for_leader_1 = committee
@@ -467,7 +467,7 @@ fn indirect_skip() {
         .filter(|x| x.authority != leader_2)
         .collect();
 
-    // Only f+1 validators connect to the 2nd leader.
+    // Only f+1 replicas connect to the 2nd leader.
     let mut references = Vec::new();
 
     let connections_with_leader_2 = committee

--- a/crates/consensus/src/tests/multi_committer_tests.rs
+++ b/crates/consensus/src/tests/multi_committer_tests.rs
@@ -461,7 +461,7 @@ fn indirect_commit() {
         .filter(|x| x.authority != leader_elector.elect_leader(leader_round_1))
         .collect();
 
-    // Only 2f+1 validators vote for the that leader.
+    // Only 2f+1 replicas vote for the that leader.
     let connections_with_leader_1 = committee
         .authorities()
         .take(strong_quorum as usize)
@@ -478,7 +478,7 @@ fn indirect_commit() {
     let references_without_votes_for_leader_1 =
         build_dag_layer(connections_without_leader_1, &mut storage);
 
-    // Only f+1 validators certify that leader.
+    // Only f+1 replicas certify that leader.
     let mut references_3 = Vec::new();
 
     let connections_with_votes_for_leader_1 = committee
@@ -573,7 +573,7 @@ fn indirect_skip() {
         .filter(|x| x.authority != leader_2)
         .collect();
 
-    // Only f+1 validators connect to that leader.
+    // Only f+1 replicas connect to that leader.
     let mut references = Vec::new();
 
     let connections_with_leader_2 = committee

--- a/crates/consensus/src/tests/pipelined_committer_tests.rs
+++ b/crates/consensus/src/tests/pipelined_committer_tests.rs
@@ -304,7 +304,7 @@ fn indirect_commit() {
         .filter(|x| x.authority != leader_elector.elect_leader(leader_round_1))
         .collect();
 
-    // Only 2f+1 validators vote for the 1st leader.
+    // Only 2f+1 replicas vote for the 1st leader.
     let connections_with_leader_1 = committee
         .authorities()
         .take(strong_quorum as usize)
@@ -321,7 +321,7 @@ fn indirect_commit() {
     let references_without_votes_for_leader_1 =
         build_dag_layer(connections_without_leader_1, &mut storage);
 
-    // Only f+1 validators certify the 1st leader.
+    // Only f+1 replicas certify the 1st leader.
     let mut references_3 = Vec::new();
 
     let connections_with_votes_for_leader_1 = committee
@@ -407,7 +407,7 @@ fn indirect_skip() {
         .filter(|x| x.authority != leader_elector.elect_leader(leader_round_4))
         .collect();
 
-    // Only f+1 validators connect to the 4th leader.
+    // Only f+1 replicas connect to the 4th leader.
     let mut references_5 = Vec::new();
 
     let connections_with_leader_4 = committee

--- a/crates/orchestrator/readme.md
+++ b/crates/orchestrator/readme.md
@@ -77,14 +77,14 @@ a red number are stopped.
 ## Step 4. Running benchmarks
 
 Running benchmarks involves installing the specified version of the codebase on the remote machines
-and running one validator and one load generator per instance. For example, the following command
-benchmarks a committee of 10 validators under a constant load of 200 tx/s:
+and running one replica and one load generator per instance. For example, the following command
+benchmarks a committee of 10 replicas under a constant load of 200 tx/s:
 
 ```bash
 cargo run --bin orchestrator -- benchmark --committee 10 --loads 200
 ```
 
-In a network of 10 validators, each with a corresponding load generator, each load generator
+In a network of 10 replicas, each with a corresponding load generator, each load generator
 submits a fixed load of 20 tx/s. Performance measurements are collected by regularly scraping the
 Prometheus metrics exposed by the load generators. The `orchestrator` binary provides additional
 commands to run a specific number of load generators on separate machines.

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -361,7 +361,7 @@ impl<P: ProtocolCommands + ProtocolMetrics> Orchestrator<P> {
 
     /// Deploy the nodes.
     pub async fn run_nodes(&self, parameters: &BenchmarkParameters) -> TestbedResult<()> {
-        display::action("\nDeploying validators");
+        display::action("\nDeploying replicas");
 
         // Select the instances to run.
         let (_, nodes, _) = self.select_instances(parameters)?;
@@ -599,7 +599,7 @@ impl<P: ProtocolCommands + ProtocolMetrics> Orchestrator<P> {
                 latest_committee_size = parameters.nodes;
             }
 
-            // Deploy the validators.
+            // Deploy the replicas.
             self.run_nodes(&parameters).await?;
             if parameters.settings.benchmark_duration.as_secs() == 0 {
                 return Ok(());

--- a/crates/simulator/examples/suite.yaml
+++ b/crates/simulator/examples/suite.yaml
@@ -2,54 +2,58 @@
 #
 # The top-level YAML sequence lets you run several simulations sequentially
 # with one command. Each item is a full SimulationConfig: any field omitted
-# falls back to the same default as a single-config run (see default.yaml).
+# falls back to the same default as a single-config run (see single.yaml for
+# the full list of tunables and their defaults).
 #
 # Run with:
 #   cargo run -p cli -- simulate --config-path crates/simulator/examples/suite.yaml
 #
 # A final summary table is printed at the end showing each run's consistency
 # and committed-leader count.
+# Small honest committee with a customized load generator. The load generator
+# is enabled by default; this entry shows how to override its parameters.
+# Omit the `load_generator` block to use the built-in defaults.
 - name: baseline
   committee_size: 4
   duration_secs: 30
   load_generator:
-    load: 100
-    transaction_size: 512
-    initial_delay: 0s
+    load: 100 # transactions per second
+    transaction_size: 512 # bytes per transaction (must exceed 16-byte header)
+    initial_delay: 0s # humantime: "0s", "500ms", "30s"
+# Stresses the committee-size axis: more authorities, same network conditions.
 - name: larger-committee
   committee_size: 10
   duration_secs: 30
-  load_generator:
-    load: 100
-    transaction_size: 512
-    initial_delay: 0s
+# Stresses the latency axis: WAN-like link delays exercise timeout paths.
+# latency_min_ms / latency_max_ms define the uniform link-latency range.
 - name: high-latency
   committee_size: 7
   duration_secs: 30
   latency_min_ms: 200
   latency_max_ms: 400
-  load_generator:
-    load: 100
-    transaction_size: 512
-    initial_delay: 0s
+# Fault scenario: one authority is fully isolated. Consensus must still
+# progress with the remaining 2f+1 stake.
+# Topology options (also documented in single.yaml):
+#   fullMesh                   - every node connected to every other (default)
+#   oneDown: <node_index>      - one node isolated from the rest
+#   star: <center_index>       - only the center talks to everyone else
+#   partition:                 - partition into groups of node indices
+#     - [0, 1]
+#     - [2, 3, 4, 5, 6, 7, 8, 9]
 - name: one-down
   committee_size: 7
   duration_secs: 30
   topology:
     oneDown: 0
-  load_generator:
-    load: 100
-    transaction_size: 512
-    initial_delay: 0s
+# Degenerate topology: everyone talks only through node 0. Useful for
+# probing how the protocol behaves when a single node becomes a bottleneck.
 - name: star
   committee_size: 7
   duration_secs: 30
   topology:
     star: 0
-  load_generator:
-    load: 100
-    transaction_size: 512
-    initial_delay: 0s
+# Network split: the committee is partitioned into two disjoint groups,
+# neither of which holds enough stake to commit on its own.
 - name: partition
   committee_size: 6
   duration_secs: 30
@@ -57,10 +61,8 @@
     partition:
       - [0, 1, 2]
       - [3, 4, 5]
-  load_generator:
-    load: 100
-    transaction_size: 512
-    initial_delay: 0s
+# Protocol variant: runs mahi-mahi instead of the default mysticeti.
+# See single.yaml for the full list of supported consensus protocols.
 - name: mahi-mahi
   committee_size: 7
   duration_secs: 30
@@ -69,7 +71,3 @@
       protocol: mahiMahi
       leader_count: 2
       wave_length: 4
-  load_generator:
-    load: 100
-    transaction_size: 512
-    initial_delay: 0s

--- a/crates/simulator/src/runner.rs
+++ b/crates/simulator/src/runner.rs
@@ -35,12 +35,12 @@ pub struct SimulationResults {
 }
 
 impl SimulationResults {
-    /// Committed-leader count per validator, in authority order.
+    /// Committed-leader count per replica, in authority order.
     pub fn commit_counts(&self) -> Vec<usize> {
         self.committed_leaders.iter().map(|v| v.len()).collect()
     }
 
-    /// True when every validator committed the exact same number of leaders.
+    /// True when every replica committed the exact same number of leaders.
     pub fn uniform_commits(&self) -> bool {
         let counts = self.commit_counts();
         counts


### PR DESCRIPTION
## Summary
- per-validator table now renders `validator` as the authority letter (A, B, …) via `Authority`'s `Display` impl, matching the rest of the codebase
- `mean latency` column replaced with `p50 latency` + `p90 latency`, mirroring the happy-path headline summary at `reporter.rs:122`
- `crates/simulator/examples/suite.yaml` docs inline: per-entry comments explaining what axis each run exercises; `load_generator` block dropped from every entry except `baseline` (it's on by default); `initial_delay: 0s` kept on the baseline override so the replica's 30 s field-default doesn't swallow a 30 s run

## Test plan
- [x] `cargo build -p cli`
- [x] pre-commit hooks (fmt, clippy, cargo-test)
- [ ] `cargo run -p cli -- simulate --config-path crates/simulator/examples/suite.yaml` — verify baseline now reports p50/p90 and validators render as letters