### PR TITLE
fix: advance committer cursor through trailing skips

### DIFF
--- a/crates/consensus/src/committer.rs
+++ b/crates/consensus/src/committer.rs
@@ -6,7 +6,7 @@ use std::{collections::VecDeque, sync::Arc};
 use crate::{base::BaseCommitter, leader::LeaderElector, protocol::Protocol};
 use dag::{
     authority::Authority,
-    block::{BlockReference, RoundNumber},
+    block::RoundNumber,
     committee::Committee,
     committee::Stake,
     consensus::{DagConsensus, LeaderStatus},
@@ -58,15 +58,16 @@ impl Committer {
     }
 
     /// Try to commit part of the dag. This function is idempotent and returns a list of
-    /// ordered decided leaders.
-    #[tracing::instrument(level = "debug", skip_all, fields(last_decided = %last_decided))]
+    /// ordered decided leaders. `last_decided` is the slot of the most recently consumed
+    /// decision; pass `None` on a fresh start to yield every decided leader from round 0
+    /// upward.
+    #[tracing::instrument(level = "debug", skip_all, fields(last_decided = ?last_decided))]
     pub(crate) fn try_commit(
         &mut self,
-        last_decided: BlockReference,
+        last_decided: Option<(RoundNumber, Authority)>,
     ) -> impl Iterator<Item = LeaderStatus> + '_ {
         let highest_known_round = self.block_reader.highest_round();
-        let last_decided_round = last_decided.round();
-        let last_decided_round_authority = (last_decided.round(), last_decided.authority);
+        let last_decided_round = last_decided.map(|(round, _)| round).unwrap_or(0);
 
         // Try to decide as many leaders as possible, starting with the highest round.
         self.leaders.clear();
@@ -98,10 +99,13 @@ impl Committer {
         // The decided sequence is the longest prefix of decided leaders.
         self.leaders
             .drain(..)
-            // Skip all leaders before the last decided round.
-            .skip_while(move |x| (x.round(), x.authority()) != last_decided_round_authority)
-            // Skip the last decided leader.
-            .skip(1)
+            // Position past the previously-yielded decision, if any. When `None`
+            // (fresh start), yield every decided leader from round 0 upward.
+            .skip_while(move |x| match last_decided {
+                Some(round_author) => (x.round(), x.authority()) != round_author,
+                None => false,
+            })
+            .skip(if last_decided.is_some() { 1 } else { 0 })
             // Filter out all the genesis.
             .filter(|x| x.round() > 0)
             // Stop the sequence upon encountering an undecided leader.
@@ -115,7 +119,10 @@ impl DagConsensus for Committer {
         self.strong_quorum
     }
 
-    fn try_commit(&mut self, last_decided: BlockReference) -> impl Iterator<Item = LeaderStatus> {
+    fn try_commit(
+        &mut self,
+        last_decided: Option<(RoundNumber, Authority)>,
+    ) -> impl Iterator<Item = LeaderStatus> {
         self.try_commit(last_decided)
     }
 

--- a/crates/consensus/src/tests/base_committer_tests.rs
+++ b/crates/consensus/src/tests/base_committer_tests.rs
@@ -6,7 +6,7 @@ use std::num::NonZeroUsize;
 use crate::{committer::Committer, leader::LeaderElector, protocol::Protocol};
 use dag::{
     authority::Authority,
-    block::BlockReference,
+    block::RoundNumber,
     consensus::LeaderStatus,
     metrics::Metrics,
     storage::Storage,
@@ -38,7 +38,7 @@ fn direct_commit() {
         },
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -77,12 +77,12 @@ fn idempotence() {
     );
 
     // Commit one block.
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let committed = committer.try_commit(last_committed).collect::<Vec<_>>();
 
     // Ensure we don't commit it again.
     let max = committed.into_iter().max().unwrap();
-    let last_committed = BlockReference::new_test(max.authority().as_u64(), max.round());
+    let last_committed = Some((max.round(), max.authority()));
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
     assert!(sequence.is_empty());
@@ -96,7 +96,7 @@ fn multiple_direct_commit() {
     let leader_elector = LeaderElector::new(committee.len());
     let wave_length = 3;
 
-    let mut last_committed = BlockReference::new_test(0, 0);
+    let mut last_committed: Option<(RoundNumber, Authority)> = None;
     for n in 1..=10 {
         let enough_blocks = wave_length * (n + 1) - 1;
         let (mut storage, _) =
@@ -131,7 +131,7 @@ fn multiple_direct_commit() {
         }
 
         let max = sequence.iter().max().unwrap();
-        last_committed = BlockReference::new_test(max.authority().as_u64(), max.round());
+        last_committed = Some((max.round(), max.authority()));
     }
 }
 
@@ -163,7 +163,7 @@ fn direct_commit_late_call() {
         },
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -207,7 +207,7 @@ fn no_genesis_commit() {
             },
         );
 
-        let last_committed = BlockReference::new_test(0, 0);
+        let last_committed: Option<(RoundNumber, Authority)> = None;
         let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
         tracing::info!("Commit sequence: {sequence:?}");
         assert!(sequence.is_empty());
@@ -257,7 +257,7 @@ fn no_leader() {
         },
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -317,7 +317,7 @@ fn direct_skip() {
         },
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -426,7 +426,7 @@ fn indirect_commit() {
         },
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
     assert_eq!(sequence.len(), 2);
@@ -503,7 +503,7 @@ fn indirect_skip() {
         },
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
     assert_eq!(sequence.len(), 3);
@@ -596,8 +596,66 @@ fn undecided() {
         },
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
     assert!(sequence.is_empty());
+}
+
+/// Once a Skip is yielded, the next `try_commit` call seeded with that skip's slot must
+/// not re-yield it. Otherwise `committed_leaders_total{commit_type=*-skip}` would inflate
+/// on every tick that rederives the same trailing skip from the (unchanged) DAG.
+#[test]
+#[tracing_test::traced_test]
+fn trailing_skip_not_re_yielded() {
+    let committee = committee(4);
+    let leader_elector = LeaderElector::new(committee.len());
+    let wave_length = 3;
+
+    let (mut storage, _) =
+        Storage::new_for_tests(Authority::from(0u64), Metrics::new_for_test(0), &committee);
+
+    // Build the same DAG as `direct_skip` so the only decision is one Skip.
+    let leader_round_1 = wave_length;
+    let references_1 = build_dag(&committee, &mut storage, None, leader_round_1);
+    let references_without_leader_1: Vec<_> = references_1
+        .into_iter()
+        .filter(|x| x.authority != leader_elector.elect_leader(leader_round_1))
+        .collect();
+    let decision_round_1 = 2 * wave_length - 1;
+    build_dag(
+        &committee,
+        &mut storage,
+        Some(references_without_leader_1),
+        decision_round_1,
+    );
+
+    let mut committer = Committer::new(
+        committee.clone(),
+        storage.block_reader().clone(),
+        Protocol {
+            strong_quorum: 2 * committee.total_stake() / 3 + 1,
+            weak_quorum: 2 * committee.total_stake() / 3 + 1,
+            wave_length: 3,
+            leader_count: NonZeroUsize::new(1).unwrap(),
+            pipeline: false,
+            leader_wait: false,
+            require_crypto: false,
+        },
+    );
+
+    let first = committer.try_commit(None).collect::<Vec<_>>();
+    assert!(
+        matches!(
+            first.last(),
+            Some(LeaderStatus::DirectSkip(..) | LeaderStatus::IndirectSkip(..)),
+        ),
+        "test precondition: last decision must be a Skip, got {first:?}",
+    );
+
+    let seed = first
+        .last()
+        .map(|status| (status.round(), status.authority()));
+    let second = committer.try_commit(seed).collect::<Vec<_>>();
+    assert!(second.is_empty(), "trailing skip re-yielded: {second:?}");
 }

--- a/crates/consensus/src/tests/multi_committer_tests.rs
+++ b/crates/consensus/src/tests/multi_committer_tests.rs
@@ -6,7 +6,7 @@ use std::num::NonZeroUsize;
 use crate::{committer::Committer, leader::LeaderElector, protocol::Protocol};
 use dag::{
     authority::Authority,
-    block::BlockReference,
+    block::RoundNumber,
     consensus::LeaderStatus,
     metrics::Metrics,
     storage::Storage,
@@ -39,7 +39,7 @@ fn direct_commit() {
             },
         );
 
-        let last_committed = BlockReference::new_test(0, 0);
+        let last_committed: Option<(RoundNumber, Authority)> = None;
         let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
         tracing::info!("Commit sequence: {sequence:?}");
 
@@ -83,12 +83,12 @@ fn idempotence() {
         );
 
         // Commit one block.
-        let last_committed = BlockReference::new_test(0, 0);
+        let last_committed: Option<(RoundNumber, Authority)> = None;
         let committed = committer.try_commit(last_committed).collect::<Vec<_>>();
 
         // Ensure we don't commit it again.
         let last = committed.into_iter().last().unwrap();
-        let last_committed = BlockReference::new_test(last.authority().as_u64(), last.round());
+        let last_committed = Some((last.round(), last.authority()));
         let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
         tracing::info!("Commit sequence: {sequence:?}");
         assert!(sequence.is_empty());
@@ -106,7 +106,7 @@ fn multiple_direct_commit() {
     let wave_length = 3;
     let leader_count = strong_quorum as usize;
 
-    let mut last_committed = BlockReference::new_test(0, 0);
+    let mut last_committed: Option<(RoundNumber, Authority)> = None;
     for n in 1..=10 {
         let enough_blocks = wave_length * (n + 1) - 1;
         let (mut storage, _) =
@@ -144,7 +144,7 @@ fn multiple_direct_commit() {
         }
 
         let last = sequence.iter().last().unwrap();
-        last_committed = BlockReference::new_test(last.authority().as_u64(), last.round());
+        last_committed = Some((last.round(), last.authority()));
     }
 }
 
@@ -161,7 +161,7 @@ fn direct_commit_partial_round() {
 
     let first_leader_round = wave_length;
     let first_leader = leader_elector.elect_leader(first_leader_round);
-    let last_committed = BlockReference::new_test(first_leader.as_u64(), first_leader_round);
+    let last_committed = Some((first_leader_round, first_leader));
 
     let enough_blocks = 2 * wave_length - 1;
     let (mut storage, _) =
@@ -228,7 +228,7 @@ fn direct_commit_late_call() {
         },
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -278,7 +278,7 @@ fn no_genesis_commit() {
             },
         );
 
-        let last_committed = BlockReference::new_test(0, 0);
+        let last_committed: Option<(RoundNumber, Authority)> = None;
         let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
         tracing::info!("Commit sequence: {sequence:?}");
         assert!(sequence.is_empty());
@@ -331,7 +331,7 @@ fn no_leader() {
         },
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -407,7 +407,7 @@ fn direct_skip() {
         },
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -530,7 +530,7 @@ fn indirect_commit() {
         },
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
     assert_eq!(sequence.len(), 2 * leader_count);
@@ -609,7 +609,7 @@ fn indirect_skip() {
         },
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
     assert_eq!(sequence.len(), 3 * leader_count);
@@ -731,7 +731,7 @@ fn undecided() {
         },
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
     assert!(sequence.is_empty());

--- a/crates/consensus/src/tests/pipelined_committer_tests.rs
+++ b/crates/consensus/src/tests/pipelined_committer_tests.rs
@@ -8,7 +8,7 @@ use crate::{committer::Committer, leader::LeaderElector, protocol::Protocol};
 const WAVE_LENGTH: u64 = 3;
 use dag::{
     authority::Authority,
-    block::{Block, BlockReference},
+    block::{Block, RoundNumber},
     consensus::LeaderStatus,
     metrics::Metrics,
     storage::Storage,
@@ -33,7 +33,7 @@ fn direct_commit() {
         Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -64,12 +64,12 @@ fn idempotence() {
     );
 
     // Commit one block.
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let committed = committer.try_commit(last_committed).collect::<Vec<_>>();
 
     // Ensure we don't commit it again.
     let last = committed.into_iter().last().unwrap();
-    let last_committed = BlockReference::new_test(last.authority().as_u64(), last.round());
+    let last_committed = Some((last.round(), last.authority()));
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
     assert!(sequence.is_empty());
@@ -83,7 +83,7 @@ fn multiple_direct_commit() {
     let leader_elector = LeaderElector::new(committee.len());
     let wave_length = WAVE_LENGTH;
 
-    let mut last_committed = BlockReference::new_test(0, 0);
+    let mut last_committed: Option<(RoundNumber, Authority)> = None;
     for n in 1..=10 {
         let enough_blocks = n + (wave_length - 1);
         let (mut storage, _) =
@@ -110,7 +110,7 @@ fn multiple_direct_commit() {
         }
 
         let last = sequence.into_iter().last().unwrap();
-        last_committed = BlockReference::new_test(last.authority().as_u64(), last.round());
+        last_committed = Some((last.round(), last.authority()));
     }
 }
 
@@ -134,7 +134,7 @@ fn direct_commit_late_call() {
         Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -170,7 +170,7 @@ fn no_genesis_commit() {
             Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
         );
 
-        let last_committed = BlockReference::new_test(0, 0);
+        let last_committed: Option<(RoundNumber, Authority)> = None;
         let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
         tracing::info!("Commit sequence: {sequence:?}");
         assert!(sequence.is_empty());
@@ -212,7 +212,7 @@ fn no_leader() {
         Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -264,7 +264,7 @@ fn direct_skip() {
         Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
 
@@ -367,7 +367,7 @@ fn indirect_commit() {
         Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
     assert_eq!(sequence.len(), 5);
@@ -440,7 +440,7 @@ fn indirect_skip() {
         Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
     assert_eq!(sequence.len(), 7);
@@ -527,7 +527,7 @@ fn undecided() {
         Protocol::mysticeti(committee.total_stake(), NonZeroUsize::new(1).unwrap()),
     );
 
-    let last_committed = BlockReference::new_test(0, 0);
+    let last_committed: Option<(RoundNumber, Authority)> = None;
     let sequence = committer.try_commit(last_committed).collect::<Vec<_>>();
     tracing::info!("Commit sequence: {sequence:?}");
     assert!(sequence.is_empty());

--- a/crates/dag/src/block.rs
+++ b/crates/dag/src/block.rs
@@ -46,7 +46,7 @@ use crate::{
 pub type RoundNumber = u64;
 
 /// The round of genesis blocks, which are trusted by construction and never sent over the wire.
-const GENESIS_ROUND: RoundNumber = 0;
+pub const GENESIS_ROUND: RoundNumber = 0;
 
 /// A block in the DAG. Contains references to prior-round blocks, a batch of transactions, and a
 /// signature from the proposing authority.

--- a/crates/dag/src/consensus.rs
+++ b/crates/dag/src/consensus.rs
@@ -25,8 +25,14 @@ pub trait DagConsensus: Send + 'static {
 
     /// Decide leaders. Returns an ordered sequence of
     /// decided leaders. Idempotent for the same DAG
-    /// state.
-    fn try_commit(&mut self, last_decided: BlockReference) -> impl Iterator<Item = LeaderStatus>;
+    /// state. `last_decided` is the slot
+    /// `(round, authority)` of the most recently consumed
+    /// decision — the caller's cursor. `None` means "no
+    /// decision consumed yet".
+    fn try_commit(
+        &mut self,
+        last_decided: Option<(RoundNumber, Authority)>,
+    ) -> impl Iterator<Item = LeaderStatus>;
 
     /// Return the leaders for a given round. The syncer
     /// may give those leaders extra time for liveness.

--- a/crates/dag/src/core.rs
+++ b/crates/dag/src/core.rs
@@ -19,18 +19,16 @@ use self::{
 };
 use crate::{
     authority::Authority,
-    block::{Block, BlockReference, RoundNumber, transaction::Transaction},
+    block::{Block, BlockReference, GENESIS_ROUND, RoundNumber, transaction::Transaction},
     block_store::{CommitData, OwnBlockData},
-    committee::Committee,
-    committee::Stake,
-    consensus::{CommittedSubDag, DagConsensus},
+    committee::{Committee, Stake},
+    consensus::{CommittedSubDag, DagConsensus, LeaderStatus},
     context::Ctx,
     crypto::{CryptoEngine, CryptoVerifier},
     data::Data,
     metrics::Metrics,
     state::RecoveredState,
-    storage::BlockReader,
-    storage::Storage,
+    storage::{BlockReader, Storage},
     wal::{WalPosition, WalSyncer},
 };
 
@@ -42,7 +40,7 @@ pub struct Core<C: Ctx, D: DagConsensus> {
     authority: Authority,
     threshold_clock: ThresholdClockAggregator,
     pub(crate) committee: Arc<Committee>,
-    last_commit_leader: BlockReference,
+    last_decided: Option<(RoundNumber, Authority)>,
     storage: Storage,
     pub metrics: Arc<Metrics>,
     fsync: bool,
@@ -124,7 +122,8 @@ impl<C: Ctx, D: DagConsensus> Core<C, D> {
             authority,
             threshold_clock,
             committee,
-            last_commit_leader: last_committed_leader.unwrap_or_default(),
+            last_decided: last_committed_leader
+                .map(|leader_ref| (leader_ref.round(), leader_ref.authority)),
             storage,
             metrics,
             fsync,
@@ -295,28 +294,30 @@ impl<C: Ctx, D: DagConsensus> Core<C, D> {
 
     pub fn try_commit(&mut self) -> Vec<Data<Block>> {
         let metrics = &self.metrics;
+        let mut latest = self.last_decided;
         let sequence: Vec<_> = self
             .committer
-            .try_commit(self.last_commit_leader)
-            .inspect(|leader| metrics.inc_decided_leaders(leader))
-            .filter_map(|leader| leader.into_decided_block())
+            .try_commit(self.last_decided)
+            .inspect(|leader| {
+                metrics.inc_decided_leaders(leader);
+                latest = Some((leader.round(), leader.authority()));
+            })
+            .filter_map(LeaderStatus::into_decided_block)
             .collect();
-
-        if let Some(last) = sequence.last() {
-            self.last_commit_leader = *last.reference();
-        }
-
+        self.last_decided = latest;
         sequence
     }
 
     pub fn cleanup(&self) {
         const RETAIN_BELOW_COMMIT_ROUNDS: RoundNumber = 100;
 
-        self.storage.block_reader().cleanup(
-            self.last_commit_leader
-                .round()
-                .saturating_sub(RETAIN_BELOW_COMMIT_ROUNDS),
-        );
+        let last_decided_round = self
+            .last_decided
+            .map(|(round, _)| round)
+            .unwrap_or(GENESIS_ROUND);
+        self.storage
+            .block_reader()
+            .cleanup(last_decided_round.saturating_sub(RETAIN_BELOW_COMMIT_ROUNDS));
 
         self.block_handler.cleanup();
     }
@@ -331,9 +332,13 @@ impl<C: Ctx, D: DagConsensus> Core<C, D> {
 
         // Leader round check. The floor of 1 keeps `leader_round = quorum_round - 1`
         // positive at startup; the committer itself filters genesis (round 0) out of
-        // its output sequence. In steady state `last_commit_leader.round()` dominates
-        // the max.
-        if quorum_round > self.last_commit_leader.round().max(1) {
+        // its output sequence. In steady state the last decided leader's round
+        // dominates the max.
+        let last_decided_round = self
+            .last_decided
+            .map(|(round, _)| round)
+            .unwrap_or(GENESIS_ROUND);
+        if quorum_round > last_decided_round.max(1) {
             let leader_round = quorum_round - 1;
             let filter = |a: &Authority| connected_authorities.contains(a);
             match self.committer.get_leaders(leader_round) {


### PR DESCRIPTION
## Summary

PR #42 fixed the commit-row side of `committed_leaders_total` double-counting by moving metric emission to `Core::try_commit` via `.inspect`. But the cursor (`last_commit_leader: BlockReference`) only advanced through committed blocks, so trailing Skip decisions stayed behind the cursor. The committer's idempotent re-evaluation then re-yielded those skips on every subsequent tick, inflating the `direct-skip` / `indirect-skip` rows indefinitely — until a commit beyond them eventually arrived.

This PR replaces the cursor with `last_decided: Option<(RoundNumber, Authority)>` — exactly the two components the committer's `skip_while` already consumes internally — and advances it in the existing `.inspect` closure through every yielded leader (commit **or** skip).

## Design

- **Cursor type**: `Option<(RoundNumber, Authority)>`. `None` means "fresh start", replacing the old `BlockReference::default()` sentinel. Tuple is `Copy` — no `Clone` on `LeaderStatus`, no Arc bumps, no heap. Field shrinks 48 → 24 bytes.
- **Trait signature**: `DagConsensus::try_commit(&mut self, last_decided: Option<(RoundNumber, Authority)>) -> impl Iterator<Item = LeaderStatus>`.
- **`cleanup()` / `ready_new_block()`**: read `last_decided.map(|(r, _)| r).unwrap_or(GENESIS_ROUND)` instead of `last_commit_leader.round()`. Semantic shift: bounded by `wave_length - 1` rounds (skips get decided that far behind the leading edge). Immaterial vs. the 100-round retention window; bounded latency hit for liveness (the threshold clock still opens the gate every round).
- **Recovery**: extracts `(ref.round(), ref.authority)` from the persisted `BlockReference` at `Core::open`. No storage-format change, no block lookup.

## Regression guard

New test `trailing_skip_not_re_yielded` in `base_committer_tests.rs`: builds the `direct_skip` scenario, calls `try_commit(None)`, asserts the last yielded decision is a Skip, then calls `try_commit(Some((skip.round, skip.authority)))` and asserts the result is empty. Load-bearing assertion for the fix.

## Audit

`refactor-guardian` verdict: **SAFE**.
- Behavior preserved on both `Some` and `None` cursor paths across multi-leader and pipelined configs.
- Zero new allocations on the hot path. No Arc bumps. No clones. Field footprint shrinks.
- Metric name, labels, emission-point, and counter type all unchanged — only numeric drift is the elimination of the pre-existing double-count.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 32 consensus (+1 regression test), 41 dag
- [x] `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings`
- [x] Pre-commit hook green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)