### PR TITLE
chore: ignore Claude Code runtime + local settings files

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"ed897607-cae9-4025-9502-24f9cbdad7d4","pid":46708,"acquiredAt":1776847262734}

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ tarpaulin-report.html
 
 # Claude Code
 .claude/worktrees/
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
 
 # OS
 .DS_Store


### PR DESCRIPTION
## Summary

- Untrack `.claude/scheduled_tasks.lock` — runtime state written by Claude Code's scheduler, should never have been committed.
- Explicitly ignore `.claude/settings.local.json` — Claude Code's convention is that `*.local.json` files hold user-specific overrides.

## What stays tracked

- `.claude/agents/` — shared agent configs (e.g. `refactor-guardian`).
- `.claude/agent-memory/` — accumulated findings from the refactor-guardian, useful across contributors.

## Test plan

- [x] `git status` is clean after first run of any workflow that touches `.claude/scheduled_tasks.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)