### PR TITLE
feat: local-testbed reporting via Exporter, with --duration / --perpetual

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -92,6 +92,31 @@ pub enum Command {
         /// Path to custom load generator config (YAML). Uses defaults if omitted.
         #[arg(long, value_name = "FILE")]
         load_generator_config_path: Option<PathBuf>,
+        /// Run for this many seconds, then collect results and shut down. Ignored if
+        /// `--perpetual` is set.
+        #[arg(
+            long,
+            value_name = "SECS",
+            default_value_t = 20,
+            conflicts_with = "perpetual"
+        )]
+        duration: u64,
+        /// Run forever; collect results and shut down on Ctrl-C. Sending Ctrl-C twice
+        /// aborts immediately without a summary.
+        #[arg(long, conflicts_with = "duration")]
+        perpetual: bool,
+        /// Heartbeat cadence, in seconds, used in `--perpetual` mode to print live
+        /// aggregated stats to stderr. No effect under `--duration`.
+        #[arg(long, value_name = "SECS", default_value_t = 5)]
+        heartbeat_interval: u64,
+        /// Directory for tracing logs, replica WALs, and run artefacts (`config.yaml`,
+        /// `meta.yaml`, `metrics.prom`). Wiped clean at the start of every run.
+        #[arg(long, value_name = "DIR", default_value = "local-testbed")]
+        output_dir: PathBuf,
+        /// Also write the committed sub-DAG to `<output_dir>/dag.ndjson` (one committed
+        /// sub-DAG per line). Off by default — DAG dumps can be many GB.
+        #[arg(long)]
+        export_dag: bool,
     },
 
     /// Print the startup banner and exit.

--- a/crates/cli/src/commands/testbed.rs
+++ b/crates/cli/src/commands/testbed.rs
@@ -3,34 +3,82 @@
 
 use std::{
     fs,
+    io::{BufWriter, Write as _},
     net::{IpAddr, Ipv4Addr},
     path::PathBuf,
+    sync::Arc,
+    time::{Duration, Instant},
 };
 
-use dag::{authority::Authority, config::ImportExport, context::TokioCtx};
-use eyre::{Context, Result};
+use dag::{
+    authority::Authority,
+    config::ImportExport,
+    context::TokioCtx,
+    metrics::{AggregateMetrics, Metrics, MetricsSnapshot, RunKind, RunResult},
+};
+use eyre::{Context, Result, eyre};
 use replica::{
     builder::ReplicaBuilder,
     config::{LoadGeneratorConfig, PrivateReplicaConfig, PublicReplicaConfig, ReplicaParameters},
     prometheus::{MetricsRegistry, PrometheusServer},
+    replica::ReplicaHandle,
 };
+use serde::Serialize;
+use tokio::signal;
 use tracing_subscriber::filter::LevelFilter;
 
-use crate::{terminal, tracing::ReplicaTracing};
+use crate::{
+    exporter::Exporter,
+    terminal::{BannerPrinter, table},
+    tracing::ReplicaTracing,
+};
 
+/// Configuration of one local-testbed run, persisted to `<output_dir>/config.yaml`
+/// alongside the rest of the exporter artefacts.
+#[derive(Clone, Serialize)]
+pub struct TestbedConfig {
+    pub committee_size: usize,
+    pub mode: Mode,
+    pub heartbeat_interval_secs: u64,
+    pub transaction_size_bytes: usize,
+    pub load_tx_per_sec: usize,
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum Mode {
+    Duration { secs: u64 },
+    Perpetual,
+}
+
+#[allow(clippy::too_many_arguments)]
 pub async fn local_testbed(
     committee_size: usize,
     replica_parameters_path: Option<PathBuf>,
     load_generator_config_path: Option<PathBuf>,
+    duration: u64,
+    perpetual: bool,
+    heartbeat_interval: u64,
+    output_dir: PathBuf,
+    export_dag: bool,
     log_level: Option<LevelFilter>,
     log_file: Option<PathBuf>,
 ) -> Result<()> {
-    let _guard = match log_level {
-        Some(level) => ReplicaTracing::new(level),
-        None => ReplicaTracing::new(LevelFilter::DEBUG),
+    // Wipe + recreate the output dir so each run starts from a clean state (WAL files,
+    // tracing log, exporter artefacts). Equivalent to the prior `local-testbed` reset.
+    if output_dir.exists() {
+        fs::remove_dir_all(&output_dir)
+            .wrap_err_with(|| format!("Failed to remove '{}'", output_dir.display()))?;
     }
-    .with_log_file(log_file)
-    .setup()?;
+    let exporter = Exporter::new(output_dir.clone())?;
+
+    // Tracing-log destination, by precedence: --log-file wins (explicit override), else
+    // exporter's tracing.log path. Default level is DEBUG so file logs stay informative;
+    // stderr stays free for banner / heartbeat / summary.
+    let log_path = log_file.or_else(|| Some(exporter.tracing_log_path()));
+    let _guard = ReplicaTracing::new(log_level.unwrap_or(LevelFilter::DEBUG))
+        .with_log_file(log_path)
+        .setup()?;
 
     // Load optional parameter overrides; fall back to defaults.
     let replica_parameters = match replica_parameters_path {
@@ -48,14 +96,25 @@ pub async fn local_testbed(
         None => LoadGeneratorConfig::default(),
     };
 
+    let mode = if perpetual {
+        Mode::Perpetual
+    } else {
+        Mode::Duration { secs: duration }
+    };
+
     // Print the startup banner.
     let nodes = committee_size.to_string();
     let tx_size = load_generator_config.transaction_size.to_string();
     let load_str = load_generator_config.load.to_string();
-    terminal::BannerPrinter::new(
+    let mode_str = match mode {
+        Mode::Duration { secs } => format!("Duration {secs}s"),
+        Mode::Perpetual => "Perpetual".to_string(),
+    };
+    BannerPrinter::new(
         "Mysticeti",
         &[
             ("Mode", "Local Testbed"),
+            ("Run", &mode_str),
             ("Nodes", &nodes),
             ("Tx size", &tx_size),
             ("Load", &load_str),
@@ -63,46 +122,48 @@ pub async fn local_testbed(
     )
     .print();
 
+    let testbed_config = TestbedConfig {
+        committee_size,
+        mode,
+        heartbeat_interval_secs: heartbeat_interval,
+        transaction_size_bytes: load_generator_config.transaction_size,
+        load_tx_per_sec: load_generator_config.load,
+    };
+
     // Generate a localhost public config with the chosen parameters.
     let ips = vec![IpAddr::V4(Ipv4Addr::LOCALHOST); committee_size];
     let public_config =
         PublicReplicaConfig::new_for_benchmarks(ips).with_parameters(replica_parameters);
 
-    // Prepare a clean working directory for the replicas' WAL files.
-    let working_dir = PathBuf::from("local-testbed");
-    match fs::remove_dir_all(&working_dir) {
-        Ok(_) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => {
-            return Err(e).wrap_err(format!(
-                "Failed to remove directory '{}'",
-                working_dir.display()
-            ));
-        }
-    }
-    let private_configs = PrivateReplicaConfig::new_for_benchmarks(&working_dir, committee_size);
+    let private_configs = PrivateReplicaConfig::new_for_benchmarks(&output_dir, committee_size);
     for private_config in &private_configs {
-        fs::create_dir_all(&private_config.storage_path).wrap_err(format!(
-            "Failed to create directory '{}'",
-            private_config.storage_path.display()
-        ))?;
+        fs::create_dir_all(&private_config.storage_path).wrap_err_with(|| {
+            format!(
+                "Failed to create directory '{}'",
+                private_config.storage_path.display()
+            )
+        })?;
     }
 
     tracing::info!("Starting local testbed with {committee_size} replicas");
 
-    // Spin up each replica: run it, start its load generator, expose its metrics.
-    // Each replica gets its own registry and metrics server on a distinct port.
-    let mut handles = Vec::with_capacity(committee_size);
+    // Spin up each replica: own its `Metrics` so we can poll it live for the heartbeat,
+    // expose the registry over Prometheus, and start the load generator.
+    let mut handles: Vec<ReplicaHandle<TokioCtx>> = Vec::with_capacity(committee_size);
     let mut metrics_servers = Vec::with_capacity(committee_size);
     let mut load_generators = Vec::with_capacity(committee_size);
+    let mut metrics_per_replica: Vec<Arc<Metrics>> = Vec::with_capacity(committee_size);
     for (i, private_config) in private_configs.into_iter().enumerate() {
         let authority = Authority::from(i);
         let metrics_address = public_config
             .metrics_address(authority)
             .expect("metrics address must exist");
         let registry = MetricsRegistry::new();
+        let metrics = Metrics::new(&registry, committee_size, None);
+        metrics_per_replica.push(metrics.clone());
         let mut handle = ReplicaBuilder::new(authority, public_config.clone(), private_config)
             .with_registry(registry.clone())
+            .with_metrics(metrics)
             .build()
             .run::<TokioCtx>()
             .await?;
@@ -116,17 +177,181 @@ pub async fn local_testbed(
         handles.push(handle);
     }
 
-    tracing::info!("All {committee_size} replicas running. Press Ctrl-C to stop.");
+    let started_at = Instant::now();
 
-    // Block until the user interrupts, then tear everything down.
-    tokio::signal::ctrl_c()
-        .await
-        .wrap_err("Failed to listen for Ctrl-C")?;
+    // Heartbeat task is perpetual-only: duration mode keeps stderr quiet between
+    // banner and summary.
+    let heartbeat_handle = match mode {
+        Mode::Perpetual if heartbeat_interval > 0 => Some(spawn_heartbeat(
+            metrics_per_replica.clone(),
+            Duration::from_secs(heartbeat_interval),
+            started_at,
+        )),
+        _ => None,
+    };
 
-    tracing::info!("Shutting down...");
-    drop(handles);
-    drop(metrics_servers);
-    drop(load_generators);
+    // Wait for the run to end.
+    //
+    // Duration mode: timer wins → graceful shutdown + summary; Ctrl-C wins → abort
+    // with no summary (matching what users expect from a fixed-duration run).
+    //
+    // Perpetual mode: only Ctrl-C ends the run, and a summary is printed. A second
+    // Ctrl-C while we're collecting bypasses the summary.
+    let wait_outcome = match mode {
+        Mode::Duration { secs } => tokio::select! {
+            biased;
+            _ = signal::ctrl_c() => WaitOutcome::AbortWithoutSummary,
+            _ = tokio::time::sleep(Duration::from_secs(secs)) => WaitOutcome::CollectAndSummarize,
+        },
+        Mode::Perpetual => {
+            tracing::info!(
+                "Perpetual mode; press Ctrl-C to stop (heartbeat every {heartbeat_interval}s)."
+            );
+            signal::ctrl_c()
+                .await
+                .wrap_err("Failed to listen for Ctrl-C")?;
+            WaitOutcome::CollectAndSummarize
+        }
+    };
 
+    if let Some(handle) = heartbeat_handle {
+        handle.abort();
+    }
+
+    if matches!(wait_outcome, WaitOutcome::AbortWithoutSummary) {
+        tracing::info!("Aborting without summary.");
+        return Ok(());
+    }
+
+    // Collection. In perpetual mode, run it inside a `select!` against a second
+    // Ctrl-C: an impatient user can hit it twice to bail out before the WAL scan
+    // completes.
+    let elapsed = started_at.elapsed();
+    eprintln!("\nCollecting results…");
+
+    let collect_fut = collect_run_result(handles, testbed_config, elapsed, &exporter, export_dag);
+    let result = match mode {
+        Mode::Perpetual => tokio::select! {
+            biased;
+            _ = signal::ctrl_c() => {
+                eprintln!("Second Ctrl-C; aborting collection.");
+                return Ok(());
+            }
+            r = collect_fut => r?,
+        },
+        Mode::Duration { .. } => collect_fut.await?,
+    };
+
+    print_summary(&result);
+    exporter.write_to(&result, 1, 1, None)?;
     Ok(())
+}
+
+enum WaitOutcome {
+    CollectAndSummarize,
+    AbortWithoutSummary,
+}
+
+/// Spawn a stderr heartbeat that prints aggregated stats every `interval`. Polled live
+/// from the replicas' `Arc<Metrics>` — does not stop the replicas to read.
+fn spawn_heartbeat(
+    metrics_per_replica: Vec<Arc<Metrics>>,
+    interval: Duration,
+    started_at: Instant,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        // First tick fires immediately; skip it so the first heartbeat lands at `interval`.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            let elapsed = started_at.elapsed();
+            let snapshots: Vec<MetricsSnapshot> =
+                metrics_per_replica.iter().map(|m| m.collect()).collect();
+            let aggregate = AggregateMetrics::new(&snapshots);
+            let line = format_heartbeat(elapsed, &snapshots, &aggregate);
+            eprintln!("{line}");
+        }
+    })
+}
+
+fn format_heartbeat(
+    elapsed: Duration,
+    snapshots: &[MetricsSnapshot],
+    aggregate: &AggregateMetrics<'_>,
+) -> String {
+    let elapsed_secs = elapsed.as_secs();
+    let max_committed = snapshots
+        .iter()
+        .map(|s| s.total_committed_leaders())
+        .max()
+        .unwrap_or(0);
+    let mut parts = vec![
+        format!("[t={elapsed_secs}s]"),
+        format!("committed={max_committed}"),
+    ];
+    if let Some(rate) = aggregate.leader_committed_per_second(elapsed) {
+        parts.push(format!("{rate:.1} commits/s"));
+    }
+    if let Some(tps) = aggregate.transactions_committed_per_second(elapsed) {
+        parts.push(format!("{tps:.0} tx/s"));
+    }
+    if let (Some(p50), Some(p90)) = (aggregate.p50_latency_ms(), aggregate.p90_latency_ms()) {
+        parts.push(format!("p50 {p50:.0} ms · p90 {p90:.0} ms"));
+    }
+    parts.join(" · ")
+}
+
+async fn collect_run_result(
+    handles: Vec<ReplicaHandle<TokioCtx>>,
+    config: TestbedConfig,
+    duration: Duration,
+    exporter: &Exporter,
+    export_dag: bool,
+) -> Result<RunResult<TestbedConfig>> {
+    // Shut every replica down sequentially (the syncers borrow each other's storage during
+    // the WAL scan, so we just need the borrows to be live, not concurrent).
+    let mut syncers = Vec::with_capacity(handles.len());
+    for handle in handles {
+        syncers.push(handle.shutdown().await);
+    }
+    let (snapshots, storages): (Vec<_>, Vec<&_>) = syncers
+        .iter()
+        .map(|syncer| {
+            let core = syncer.core();
+            (core.metrics.collect(), core.storage())
+        })
+        .unzip();
+
+    let mut dag_writer = if export_dag {
+        let path = exporter.dag_path(1, 1, None)?;
+        let file = fs::File::create(&path)
+            .wrap_err_with(|| format!("creating DAG log {}", path.display()))?;
+        Some(BufWriter::new(file))
+    } else {
+        None
+    };
+
+    let mut builder = RunResult::builder(snapshots, &storages, config, duration, RunKind::Testbed);
+    if let Some(writer) = dag_writer.as_mut() {
+        builder = builder.with_dag_log(writer);
+    }
+    let result = builder.collect().map_err(|e| eyre!(e))?;
+
+    // Flush the DAG log before dropping the writer so the file is complete on disk.
+    if let Some(mut writer) = dag_writer {
+        writer.flush().wrap_err("flushing DAG log")?;
+    }
+    Ok(result)
+}
+
+fn print_summary(result: &RunResult<TestbedConfig>) {
+    use dag::metrics::Outcome;
+    let badge = match result.outcome {
+        Outcome::Pass => "PASS: Commits consistent across all replicas",
+        Outcome::NoProgress => "WARN: Safe but no leader was committed",
+        Outcome::Diverged => "FAIL: Commits DIVERGED across replicas",
+    };
+    println!("\n{badge}");
+    println!("{}", table::render(table::ReplicaRow::for_result(result)));
 }

--- a/crates/cli/src/exporter.rs
+++ b/crates/cli/src/exporter.rs
@@ -32,7 +32,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use dag::metrics::{Outcome, RunResult};
+use dag::metrics::{Outcome, RunKind, RunResult};
 use eyre::{Result, WrapErr};
 use serde::Serialize;
 use tempfile::NamedTempFile;
@@ -119,7 +119,7 @@ impl Exporter {
         let meta = Meta {
             outcome: result.outcome,
             duration_secs: result.duration.as_secs(),
-            kind: "simulation",
+            kind: result.kind,
             timestamp_unix: SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .map(|d| d.as_secs())
@@ -167,7 +167,7 @@ impl Exporter {
 struct Meta {
     outcome: Outcome,
     duration_secs: u64,
-    kind: &'static str,
+    kind: RunKind,
     /// Unix epoch seconds at the time of export. Downstream consumers render as RFC3339
     /// on their end (e.g. Python `datetime.fromtimestamp(ts, tz=timezone.utc)`).
     timestamp_unix: u64,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -61,11 +61,21 @@ async fn main() -> Result<()> {
             committee_size,
             replica_parameters_path,
             load_generator_config_path,
+            duration,
+            perpetual,
+            heartbeat_interval,
+            output_dir,
+            export_dag,
         } => {
             commands::testbed::local_testbed(
                 committee_size,
                 replica_parameters_path,
                 load_generator_config_path,
+                duration,
+                perpetual,
+                heartbeat_interval,
+                output_dir,
+                export_dag,
                 args.log_level,
                 args.log_file,
             )

--- a/crates/dag/src/metrics.rs
+++ b/crates/dag/src/metrics.rs
@@ -21,7 +21,7 @@ pub use self::names::{
     BENCHMARK_DURATION, BLOCK_SYNC_REQUESTS_SENT, LABEL_AUTHORITY, LATENCY_S, LATENCY_SQUARED_S,
     LEADER_TIMEOUT_TOTAL, SyncRequestFulfilled,
 };
-pub use self::result::{Outcome, RunResult};
+pub use self::result::{Outcome, RunKind, RunResult};
 pub use self::snapshot::MetricsSnapshot;
 pub use self::timers::{OwnedUtilizationTimer, UtilizationTimer};
 use self::{
@@ -37,11 +37,14 @@ use crate::{authority::Authority, consensus::LeaderStatus};
 pub struct Metrics {
     coarse: CoarseMetrics,
     precise: PreciseMetrics,
-    registry: Option<Registry>,
+    registry: Registry,
 }
 
 impl Metrics {
-    /// Create metrics and start the background reporter.
+    /// Create metrics and start the background reporter. The registry clone is retained
+    /// so [`Metrics::collect`] can produce a snapshot at any time (heartbeats during a
+    /// run, final summary at shutdown). The precise metrics are flushed periodically by
+    /// the background reporter, so a snapshot may lag by up to `report_interval`.
     pub fn new(
         registry: &Registry,
         committee_size: usize,
@@ -52,12 +55,13 @@ impl Metrics {
         Arc::new(Self {
             coarse,
             precise,
-            registry: None, // Not needed in production
+            registry: registry.clone(),
         })
     }
 
-    /// Create metrics for tests. The registry is stored internally
-    /// and drained on-demand via [`Metrics::collect`].
+    /// Create metrics for tests. Owns a private registry; [`Metrics::collect`] flushes
+    /// the precise channels synchronously before gathering, so snapshots are always
+    /// up-to-date.
     pub fn new_for_test(committee_size: usize) -> Arc<Self> {
         let registry = Registry::new();
         let coarse = CoarseMetrics::new(&registry);
@@ -65,7 +69,7 @@ impl Metrics {
         Arc::new(Self {
             coarse,
             precise,
-            registry: Some(registry),
+            registry,
         })
     }
 }
@@ -221,16 +225,19 @@ impl Metrics {
         }
     }
 
-    /// Flush precise metrics to Prometheus gauges and return
-    /// a snapshot of all metrics. Only works in test mode —
-    /// panics if called on production metrics.
+    /// Flush precise metrics to Prometheus gauges (in test mode only — see below) and
+    /// return a snapshot of all gathered metrics.
+    ///
+    /// Expensive: `Registry::gather()` allocates many small structs (one `MetricFamily`
+    /// per metric, one `Metric` per series, plus label-pair storage), so it's well into
+    /// "do not call in tight loops" territory — heartbeats and end-of-run pulls are fine.
+    ///
+    /// In production mode (`Metrics::new`) the precise reporter runs as a background
+    /// task that flushes periodically, so a snapshot here may lag by up to the
+    /// `report_interval` passed to the constructor.
     pub fn collect(&self) -> MetricsSnapshot {
-        let registry = self
-            .registry
-            .as_ref()
-            .expect("collect() is only available on test metrics");
         self.precise.flush();
-        MetricsSnapshot::new(registry.gather())
+        MetricsSnapshot::new(self.registry.gather())
     }
 
     /// Abort the background reporter and drop all observers.
@@ -355,12 +362,13 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "collect() is only available on test metrics")]
-    fn collect_panics_without_registry() {
+    fn production_collect_returns_snapshot_via_external_registry() {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         let _guard = runtime.enter();
         let registry = prometheus::Registry::new();
         let metrics = Metrics::new(&registry, 4, None);
-        metrics.collect();
+        metrics.set_wal_mappings(7);
+        let snapshot = metrics.collect();
+        assert_eq!(snapshot.scalar_value("wal_mappings", &[]), 7.0);
     }
 }

--- a/crates/dag/src/metrics/result.rs
+++ b/crates/dag/src/metrics/result.rs
@@ -30,6 +30,17 @@ struct DagRecord<'a> {
     commit: &'a CommitData,
 }
 
+/// What kind of run produced a [`RunResult`]. Echoed into `meta.yaml` by the
+/// exporter; downstream tooling uses it to keep simulator and testbed runs apart.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RunKind {
+    /// Discrete-event simulator run.
+    Simulation,
+    /// Single-process local testbed run.
+    Testbed,
+}
+
 /// Verdict on a single run, derived from the committed-leader sequences across replicas.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -114,6 +125,7 @@ pub struct RunResult<C> {
     pub outcome: Outcome,
     pub config: C,
     pub duration: Duration,
+    pub kind: RunKind,
 }
 
 impl<C> RunResult<C> {
@@ -125,12 +137,14 @@ impl<C> RunResult<C> {
         storages: &[S],
         config: C,
         duration: Duration,
+        kind: RunKind,
     ) -> RunResultBuilder<'_, C, S> {
         RunResultBuilder {
             metrics,
             storages,
             config,
             duration,
+            kind,
             dag_log: None,
         }
     }
@@ -155,6 +169,7 @@ pub struct RunResultBuilder<'a, C, S: Borrow<Storage>> {
     storages: &'a [S],
     config: C,
     duration: Duration,
+    kind: RunKind,
     dag_log: Option<&'a mut dyn io::Write>,
 }
 
@@ -178,6 +193,7 @@ impl<'a, C, S: Borrow<Storage>> RunResultBuilder<'a, C, S> {
             storages,
             config,
             duration,
+            kind,
             dag_log,
         } = self;
         if let Some(writer) = dag_log {
@@ -199,6 +215,7 @@ impl<'a, C, S: Borrow<Storage>> RunResultBuilder<'a, C, S> {
             outcome,
             config,
             duration,
+            kind,
         })
     }
 }
@@ -211,7 +228,7 @@ mod tests {
         authority::Authority,
         block::BlockReference,
         committee::Committee,
-        metrics::{Metrics, Outcome, RunResult},
+        metrics::{Metrics, Outcome, RunKind, RunResult},
         storage::{Storage, block_store::CommitData},
     };
 
@@ -316,10 +333,15 @@ mod tests {
         let batch = CommitData::new_for_test(&[(0, 1), (1, 2), (2, 3)]);
         let (storages, snapshots) = build_storages_with_commits(3, &batch);
 
-        let result: RunResult<()> =
-            RunResult::builder(snapshots, &storages, (), Duration::from_secs(30))
-                .collect()
-                .expect("collect");
+        let result: RunResult<()> = RunResult::builder(
+            snapshots,
+            &storages,
+            (),
+            Duration::from_secs(30),
+            RunKind::Simulation,
+        )
+        .collect()
+        .expect("collect");
 
         assert_eq!(result.outcome, Outcome::Pass);
         assert_eq!(result.duration, Duration::from_secs(30));
@@ -329,10 +351,15 @@ mod tests {
     #[test]
     fn run_result_collect_classifies_empty_run_as_no_progress() {
         let (storages, snapshots) = build_storages_with_commits(2, &[]);
-        let result: RunResult<()> =
-            RunResult::builder(snapshots, &storages, (), Duration::from_secs(5))
-                .collect()
-                .expect("collect");
+        let result: RunResult<()> = RunResult::builder(
+            snapshots,
+            &storages,
+            (),
+            Duration::from_secs(5),
+            RunKind::Simulation,
+        )
+        .collect()
+        .expect("collect");
         assert_eq!(result.outcome, Outcome::NoProgress);
     }
 
@@ -342,11 +369,16 @@ mod tests {
         let (storages, snapshots) = build_storages_with_commits(2, &batch);
 
         let mut buffer = Vec::new();
-        let result: RunResult<()> =
-            RunResult::builder(snapshots, &storages, (), Duration::from_secs(10))
-                .with_dag_log(&mut buffer)
-                .collect()
-                .expect("NDJSON write");
+        let result: RunResult<()> = RunResult::builder(
+            snapshots,
+            &storages,
+            (),
+            Duration::from_secs(10),
+            RunKind::Simulation,
+        )
+        .with_dag_log(&mut buffer)
+        .collect()
+        .expect("NDJSON write");
 
         assert_eq!(result.outcome, Outcome::Pass);
 
@@ -366,16 +398,26 @@ mod tests {
         let (storages_a, snapshots_a) = build_storages_with_commits(3, &batch);
         let (storages_b, snapshots_b) = build_storages_with_commits(3, &batch);
 
-        let plain: RunResult<()> =
-            RunResult::builder(snapshots_a, &storages_a, (), Duration::from_secs(1))
-                .collect()
-                .expect("collect");
+        let plain: RunResult<()> = RunResult::builder(
+            snapshots_a,
+            &storages_a,
+            (),
+            Duration::from_secs(1),
+            RunKind::Simulation,
+        )
+        .collect()
+        .expect("collect");
         let mut sink = Vec::new();
-        let logged: RunResult<()> =
-            RunResult::builder(snapshots_b, &storages_b, (), Duration::from_secs(1))
-                .with_dag_log(&mut sink)
-                .collect()
-                .expect("collect");
+        let logged: RunResult<()> = RunResult::builder(
+            snapshots_b,
+            &storages_b,
+            (),
+            Duration::from_secs(1),
+            RunKind::Simulation,
+        )
+        .with_dag_log(&mut sink)
+        .collect()
+        .expect("collect");
 
         assert_eq!(plain.outcome, logged.outcome);
     }

--- a/crates/simulator/src/runner.rs
+++ b/crates/simulator/src/runner.rs
@@ -13,7 +13,7 @@ use dag::{
     config::{ConfigError, ImportExport},
     context::Ctx,
     core::syncer::Syncer,
-    metrics::{Metrics, RunResult},
+    metrics::{Metrics, RunKind, RunResult},
 };
 use rand::{SeedableRng, rngs::StdRng};
 use replica::{
@@ -177,7 +177,13 @@ impl SimulationState {
 
         let duration = self.config.duration();
         let mut writer = self.dag_writer;
-        let mut builder = RunResult::builder(metrics, &storages, self.config, duration);
+        let mut builder = RunResult::builder(
+            metrics,
+            &storages,
+            self.config,
+            duration,
+            RunKind::Simulation,
+        );
         if let Some(w) = &mut writer {
             builder = builder.with_dag_log(&mut **w);
         }


### PR DESCRIPTION
## Summary

Replaces the open-ended `local-testbed` loop (banner → forever DEBUG firehose on stderr → silent shutdown on Ctrl-C) with the same `RunResult` / `Exporter` flow the simulator uses, plus two run modes:

- \`--duration <SECS>\` *(default 20s)* — runs for that long, prints a per-replica summary table, exports \`config.yaml\` / \`meta.yaml\` / \`metrics.prom\` (and \`dag.ndjson\` with \`--export-dag\`) under \`--output-dir\`. Ctrl-C aborts without a summary.
- \`--perpetual\` — runs forever. Prints a one-line aggregate heartbeat to stderr every \`--heartbeat-interval\` (default 5s). First Ctrl-C → collect + summary + exporter write. Second Ctrl-C during collection → hard abort.

Tracing always lands in \`<output_dir>/tracing.log\` at DEBUG; stderr stays clean for banner / heartbeats / final table.

## Plumbing changes that were needed

- **\`RunKind { Simulation, Testbed }\` enum on \`RunResult<C>\`** — written into \`meta.yaml\` by the exporter. Replaces a hardcoded \`\"simulation\"\` string and removes the matching parameter from \`Exporter::write_to\` — \`RunResult\` is now self-describing.
- **\`Metrics::new\` retains a clone of the external Prometheus registry** so \`Metrics::collect()\` works in production too. The \`Option<Registry>\` is gone and \`collect()\` no longer panics.

## Known follow-up

The foreground \`precise.flush()\` is still a no-op in production mode (the background reporter handles it). On short \`--duration 20\` runs, the final summary's p50/p90 latency cells can be empty until the precise reporter has flushed. Will be fixed in a separate commit by reworking \`ReporterState::Spawned\` to share a \`Mutex<Reporter>\` so foreground and background flushes use the same state.

## Test plan

- [x] \`cargo test --workspace\` passes.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] Smoke run: \`cargo run --bin mysticeti -- local-testbed --duration 5 --output-dir /tmp/testbed-smoke\` → banner → \"Collecting results…\" → PASS table → \`config.yaml\` / \`meta.yaml\` / \`metrics.prom\` / \`tracing.log\` / \`storage-A..D/\` artefacts present.
- [x] Smoke run: \`cargo run --bin mysticeti -- local-testbed --perpetual --heartbeat-interval 3 --output-dir /tmp/testbed-perpetual\` → 3-second heartbeats → SIGINT → PASS table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)