### PR TITLE
ci: bump peter-evans/create-pull-request v7.0.5 → v8.1.1

### DIFF
--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -24,9 +24,8 @@ jobs:
             --repo https://github.com/editorconfig-checker/editorconfig-checker.python \
             --repo https://github.com/google/yamlfmt \
             --repo https://github.com/crate-ci/typos
-
       - run: pre-commit run --all-files
-      - uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # pin@v7.0.5
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # pin@v8.1.1
         if: ${{ success() }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -34,7 +33,7 @@ jobs:
           title: "chore: update pre-commit hooks"
           commit-message: "chore: update pre-commit hooks"
           body: Update pre-commit hooks to latest version.
-      - uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # pin@v7.0.5
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # pin@v8.1.1
         if: ${{ failure() }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The monthly **Updates** workflow has been failing on every run since the start of 2026 (most recent: [run 24900026261](https://github.com/asonnino/mysticeti/actions/runs/24900026261), 2026-04-24). The failure is at the `git remote prune origin` step inside `peter-evans/create-pull-request`:

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/asonnino/mysticeti/':
       The requested URL returned error: 400
```

This is a known incompatibility between `peter-evans/create-pull-request@v7.0.5` and the `actions/checkout@v6` that the workflow already uses — [issue #4228 upstream](https://github.com/peter-evans/create-pull-request/issues/4228), fixed in v7.0.9.

Bumping straight to the latest, **v8.1.1**. v8 only requires Node 24 / Actions Runner v2.327.1+, which GitHub-hosted runners already provide. No parameter changes affect what this workflow uses (`token`, `branch`, `title`, `commit-message`, `body`).

Side benefit: clears the Node.js 20 deprecation warning the previous pin emits on every run.

## Test plan

- [ ] After merge, manually trigger the **Updates** workflow (`gh workflow run updates.yml --repo asonnino/mysticeti`) and verify the run succeeds — either creates the `chore/update-pre-commit-hooks` PR or exits cleanly with no diff.
- [ ] No more "Node.js 20 actions are deprecated" warning in the run logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)