### PR TITLE
ci(experiment): drop positional arg from claude-review prompt

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,6 +32,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          prompt: "/code-review:code-review"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Experiment

The Claude Code Review workflow runs successfully on every PR but never posts a review comment (e.g. PR #70 had Copilot flag 5 real issues; \`claude-review\` was green and silent). Suspected cause: the plugin invocation passes a positional URL-shaped argument that the plugin treats as the review *target* without engaging its post-a-PR-review code path. The workflow already knows the PR context from the \`pull_request\` event, so the positional arg is redundant.

**Smallest delta first**: drop the positional arg.

## What we're watching for on this PR

- ✅ **Hypothesis confirmed**: a \`claude\` bot posts a PR review/comment on this PR. Then it merges.
- ❌ **Hypothesis disproved**: \`claude-review\` check still green, no comment posted. Then the next experiment is to bump perms (\`pull-requests: write\`, \`issues: write\`) and/or switch to \`direct_prompt:\` with explicit "post inline comments" wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)