### PR TITLE
fix(cli): quiet local-testbed stderr; pad params table

### DIFF
--- a/crates/cli/src/commands/testbed.rs
+++ b/crates/cli/src/commands/testbed.rs
@@ -52,12 +52,15 @@ pub async fn local_testbed(
         .as_ref()
         .map(Exporter::tracing_log_path)
         .or(log_file);
-    let _guard = match log_level {
-        Some(level) => ReplicaTracing::new(level),
-        None => ReplicaTracing::default(),
-    }
-    .with_log_file(log_path)
-    .setup()?;
+    // When logs go to stderr, default to WARN so info chatter does not interleave
+    // with the banner/heartbeat/summary; when going to a file, keep INFO.
+    let default_level = if log_path.is_some() {
+        LevelFilter::INFO
+    } else {
+        LevelFilter::WARN
+    };
+    let level = log_level.unwrap_or(default_level);
+    let _guard = ReplicaTracing::new(level).with_log_file(log_path).setup()?;
 
     let replica_parameters = match replica_parameters_path {
         Some(path) => {

--- a/crates/cli/src/terminal.rs
+++ b/crates/cli/src/terminal.rs
@@ -84,6 +84,7 @@ impl Terminal {
         }
         if !rows.is_empty() {
             println!("{}", table::render(rows));
+            println!();
         }
 
         self.spinner.start();


### PR DESCRIPTION
## Summary

- Default `local-testbed` tracing to `WARN` when logs go to stderr so `dag` / `consensus` / `replica` INFO chatter no longer interleaves with the banner / heartbeat / summary. Keeps INFO for `--log-file` and `--output-dir` (file is operational, not user-facing). `--log-level` still overrides either path.
- Append a blank line after the per-run params table so it stops butting up against the spinner / next output.

Closes #74.

Scope is intentionally narrow — only `local-testbed`. `run` and `test-genesis` are operator-facing and stay at the existing `ReplicaTracing::default()` (INFO).

## Test plan

- [x] `cargo run --bin replica -- local-testbed --duration 3` → stderr is just banner + summary, no INFO lines.
- [x] `cargo run --bin replica -- --log-level info local-testbed --duration 3` → INFO lines from `dag`/`consensus`/`replica` reappear on stderr.
- [x] `cargo run --bin replica -- --log-file /tmp/lt.log local-testbed --duration 3` → stderr quiet, `/tmp/lt.log` contains 20 INFO lines.
- [x] `cargo run --bin replica -- local-testbed --duration 3 --output-dir /tmp/lt-out` → stderr quiet, `/tmp/lt-out/tracing.log` contains INFO.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)