### PR TITLE
fix(dag): distribute BlockReference hash buckets under disabled crypto

### DIFF
--- a/crates/dag/src/block.rs
+++ b/crates/dag/src/block.rs
@@ -75,14 +75,14 @@ pub struct Block {
 }
 
 impl Block {
-    /// Create the genesis block for an authority (round 0, no includes, no transactions, dummy
-    /// digest and default signature).
+    /// Create the genesis block for an authority (round 0, no includes, no transactions,
+    /// synthetic digest and default signature).
     pub fn genesis(authority: Authority) -> Data<Self> {
         Data::new(Self {
             reference: BlockReference {
                 authority,
                 round: GENESIS_ROUND,
-                digest: BlockDigest::dummy(),
+                digest: BlockDigest::synthetic(GENESIS_ROUND, authority),
             },
             includes: vec![],
             transactions: vec![],
@@ -116,7 +116,8 @@ impl Block {
         }
     }
 
-    /// Test-only constructor with dummy digest, no transactions, and no signature.
+    /// Test-only constructor with a synthetic digest (encoding `(round, authority)`),
+    /// no transactions, and no signature.
     #[cfg(any(test, feature = "test-utils"))]
     pub fn new_for_test(
         authority: Authority,
@@ -127,7 +128,7 @@ impl Block {
             reference: BlockReference {
                 authority,
                 round,
-                digest: BlockDigest::dummy(),
+                digest: BlockDigest::synthetic(round, authority),
             },
             includes,
             transactions: vec![],

--- a/crates/dag/src/block/reference.rs
+++ b/crates/dag/src/block/reference.rs
@@ -32,19 +32,9 @@ pub struct BlockReference {
     pub digest: BlockDigest,
 }
 
-impl Default for BlockReference {
-    fn default() -> Self {
-        Self {
-            authority: Authority::default(),
-            round: 0,
-            digest: BlockDigest::dummy(),
-        }
-    }
-}
-
 impl BlockReference {
     /// Create a test reference. For round 0, computes a real genesis digest;
-    /// for other rounds, uses a default (zero) digest.
+    /// for other rounds, uses a synthetic digest encoding `(round, authority)`.
     #[cfg(any(test, feature = "test-utils"))]
     pub fn new_test(authority: u64, round: RoundNumber) -> Self {
         let authority = Authority::new(authority);
@@ -54,7 +44,7 @@ impl BlockReference {
             Self {
                 authority,
                 round,
-                digest: BlockDigest::dummy(),
+                digest: BlockDigest::synthetic(round, authority),
             }
         }
     }

--- a/crates/dag/src/block/reference.rs
+++ b/crates/dag/src/block/reference.rs
@@ -33,8 +33,11 @@ pub struct BlockReference {
 }
 
 impl BlockReference {
-    /// Create a test reference. For round 0, computes a real genesis digest;
-    /// for other rounds, uses a synthetic digest encoding `(round, authority)`.
+    /// Create a test reference. For round 0, returns the digest produced by
+    /// [`Block::genesis`]; for other rounds, returns a synthetic digest encoding
+    /// `(round, authority)`.
+    ///
+    /// [`Block::genesis`]: super::Block::genesis
     #[cfg(any(test, feature = "test-utils"))]
     pub fn new_test(authority: u64, round: RoundNumber) -> Self {
         let authority = Authority::new(authority);

--- a/crates/dag/src/crypto.rs
+++ b/crates/dag/src/crypto.rs
@@ -81,7 +81,10 @@ impl CryptoEngine {
         timestamp_ns: u64,
     ) -> (SignatureBytes, BlockDigest) {
         if !self.enabled {
-            return (SignatureBytes::dummy(), BlockDigest::dummy());
+            return (
+                SignatureBytes::dummy(),
+                BlockDigest::synthetic(round, authority),
+            );
         }
         let content_hash = BlockDigest::new(authority, round, includes, transactions, timestamp_ns);
         let signature = self.signer.sign(content_hash.as_ref());
@@ -100,7 +103,7 @@ impl CryptoVerifier {
     /// produce the content hash, verifies the signature against it, then derives the full digest.
     pub fn verify(&self, public_key: &PublicKey, block: &Block) -> eyre::Result<BlockDigest> {
         if !self.enabled {
-            return Ok(BlockDigest::dummy());
+            return Ok(BlockDigest::synthetic(block.round(), block.author()));
         }
         let digest = BlockDigest::new(
             block.author(),

--- a/crates/dag/src/crypto/digest.rs
+++ b/crates/dag/src/crypto/digest.rs
@@ -29,6 +29,12 @@ use super::sign::SignatureBytes;
 /// Length of a block digest in bytes (Blake2b-256).
 pub const BLOCK_DIGEST_SIZE: usize = 32;
 
+/// 64-bit golden-ratio constant (`floor(2^64 / phi)`, odd). Used as a multiplier in
+/// [`BlockDigest::synthetic`] to diffuse `round` across all 8 bytes before XOR-ing
+/// in `authority`, so both dimensions contribute entropy to every byte of the bucket
+/// prefix consumed by `BlockReference::Hash`.
+const GOLDEN_RATIO_MIXER: u64 = 0x9E37_79B9_7F4A_7C15;
+
 /// A 32-byte Blake2b-256 hash that uniquely identifies a block.
 #[derive(Clone, Copy, Eq, Ord, PartialOrd, PartialEq, Hash)]
 pub struct BlockDigest([u8; BLOCK_DIGEST_SIZE]);
@@ -65,18 +71,18 @@ impl BlockDigest {
         Self(hasher.finalize().into())
     }
 
-    /// A digest that encodes `(round, author)` in its first 8 bytes, with the remaining
+    /// A digest that encodes `(round, authority)` in its first 8 bytes, with the remaining
     /// 24 bytes zeroed. Used by [`Block::genesis`], the [`CryptoEngine::disabled`] paths,
     /// and the test helpers — anywhere a real Blake2b digest is not produced. Keeps the
     /// `Hash` impl on [`BlockReference`] (which keys off the first 8 bytes) well-distributed.
-    /// Two blocks at the same `(round, author)` still collide, which matches their
+    /// Two blocks at the same `(round, authority)` still collide, which matches their
     /// indistinguishability under disabled crypto.
     ///
     /// [`Block::genesis`]: crate::block::Block::genesis
     /// [`CryptoEngine::disabled`]: super::CryptoEngine::disabled
-    pub fn synthetic(round: RoundNumber, author: Authority) -> Self {
+    pub(crate) fn synthetic(round: RoundNumber, authority: Authority) -> Self {
         let mut bytes = [0u8; BLOCK_DIGEST_SIZE];
-        let mixed = round.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ author.as_u64();
+        let mixed = round.wrapping_mul(GOLDEN_RATIO_MIXER) ^ authority.as_u64();
         bytes[..8].copy_from_slice(&mixed.to_be_bytes());
         Self(bytes)
     }

--- a/crates/dag/src/crypto/digest.rs
+++ b/crates/dag/src/crypto/digest.rs
@@ -65,9 +65,20 @@ impl BlockDigest {
         Self(hasher.finalize().into())
     }
 
-    /// Returns an all-zeros digest, used as a placeholder when crypto is disabled.
-    pub fn dummy() -> Self {
-        Self([0u8; BLOCK_DIGEST_SIZE])
+    /// A digest that encodes `(round, author)` in its first 8 bytes, with the remaining
+    /// 24 bytes zeroed. Used by [`Block::genesis`], the [`CryptoEngine::disabled`] paths,
+    /// and the test helpers — anywhere a real Blake2b digest is not produced. Keeps the
+    /// `Hash` impl on [`BlockReference`] (which keys off the first 8 bytes) well-distributed.
+    /// Two blocks at the same `(round, author)` still collide, which matches their
+    /// indistinguishability under disabled crypto.
+    ///
+    /// [`Block::genesis`]: crate::block::Block::genesis
+    /// [`CryptoEngine::disabled`]: super::CryptoEngine::disabled
+    pub fn synthetic(round: RoundNumber, author: Authority) -> Self {
+        let mut bytes = [0u8; BLOCK_DIGEST_SIZE];
+        let mixed = round.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ author.as_u64();
+        bytes[..8].copy_from_slice(&mixed.to_be_bytes());
+        Self(bytes)
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #86.

`BlockReference::Hash` (`crates/dag/src/block/reference.rs`) keys off the first 8 bytes of the digest. Under `CryptoEngine::disabled()`, every block produced via `Block::new` carried `BlockDigest::dummy()` (all zeros), so every reference collided in the same `HashMap` bucket and lookups degraded to O(n) linear scans via `PartialEq`. This hit the simulator, the local testbed, and most unit tests.

## What changed

- New `BlockDigest::synthetic(round, author)` — encodes both dimensions into the first 8 bytes via a golden-ratio mix; remaining 24 bytes zeroed.
- `BlockDigest::dummy()` removed. All non-Blake2b digest sites use `synthetic` now: `Block::genesis`, the `CryptoEngine::sign` / `CryptoVerifier::verify` disabled paths, and the test helpers (`Block::new_for_test`, `BlockReference::new_test`).
- `impl Default for BlockReference` removed — was dead code (no callers; structs deriving `Default` that mention `BlockReference` use `Option<...>` or `HashSet<...>`).

## Notes

- Production-enabled-crypto path is functionally unchanged: `crypto.sign` still goes through real Blake2b.
- Wire-format change for non-zero-authority genesis references: their `digest` now encodes the authority instead of being all zeros. All replicas running this code agree; this is a hard wire break against pre-change replicas.
- `Block::genesis(A)` and `crypto.sign(round=0, A, ..., disabled)` now produce the same digest, removing a previously latent inconsistency between the two construction paths.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` green (all crates: dag, consensus, replica, simulator, cli, smoke tests, sync tests, simulation tests)
- [x] Pre-commit hooks pass (fmt, clippy, cargo-test)
- [x] `refactor-guardian` audit: SAFE — no production drift, no `dummy`/`synthetic` mismatch among reachable callers, no perf regression
- [ ] Reviewer to spot-check the `synthetic` mix and confirm the wire-format genesis change is acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)