### PR TITLE
refactor(consensus): rename Odontoceti protocol to Blue Bottle

### DIFF
--- a/.claude/agent-memory/refactor-guardian/project_leader_timeout_wiring.md
+++ b/.claude/agent-memory/refactor-guardian/project_leader_timeout_wiring.md
@@ -15,7 +15,7 @@ Current state (post `config-cleanup`):
 - `Replica::run` / `SimulatedReplica::start` resolve via
   `round_timeout.unwrap_or_else(|| protocol.default_round_timeout())`.
 - `Protocol::default_round_timeout` returns `1s` when `leader_wait == true`
-  (Mysticeti, Odontoceti, CordialMinersPartiallySynchronous), `75ms` otherwise
+  (Mysticeti, BlueBottle, CordialMinersPartiallySynchronous), `75ms` otherwise
   (MahiMahi, CordialMinersAsynchronous).
 
 **Why:** Mysticeti's effective timeout remains 1s — identical to the historical

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ network and failure scenarios.
 
 This repository currently supports [Mysticeti](https://sonnino.com/papers/mysticeti.pdf),
 [Mahi-Mahi](https://sonnino.com/papers/mahi-mahi.pdf),
-[Odontoceti](https://sonnino.com/papers/bluebottle.pdf), [Cordial
+[Blue Bottle](https://sonnino.com/papers/bluebottle.pdf), [Cordial
 Miners](https://arxiv.org/abs/2205.09174) (both the partially synchronous and asynchronous
 variants), and [Nemo-Nemo](https://sonnino.com/papers/nemo-nemo.pdf).
 

--- a/crates/consensus/src/protocol.rs
+++ b/crates/consensus/src/protocol.rs
@@ -20,7 +20,7 @@ pub enum ConsensusProtocol {
         #[serde(default = "defaults::default_leader_count")]
         leader_count: NonZeroUsize,
     },
-    Odontoceti {
+    BlueBottle {
         #[serde(default = "defaults::default_leader_count")]
         leader_count: NonZeroUsize,
     },
@@ -77,8 +77,8 @@ impl fmt::Display for ConsensusProtocol {
             Self::Mysticeti { leader_count } => {
                 write!(f, "Mysticeti ({} leaders/round)", leader_count)
             }
-            Self::Odontoceti { leader_count } => {
-                write!(f, "Odontoceti ({} leaders/round)", leader_count)
+            Self::BlueBottle { leader_count } => {
+                write!(f, "Blue Bottle ({} leaders/round)", leader_count)
             }
             Self::MahiMahi {
                 leader_count,
@@ -104,7 +104,7 @@ impl ConsensusProtocol {
             }
             Self::CordialMinersAsynchronous => Protocol::cordial_miners_asynchronous(total_stake),
             Self::Mysticeti { leader_count } => Protocol::mysticeti(total_stake, leader_count),
-            Self::Odontoceti { leader_count } => Protocol::odontoceti(total_stake, leader_count),
+            Self::BlueBottle { leader_count } => Protocol::blue_bottle(total_stake, leader_count),
             Self::MahiMahi {
                 leader_count,
                 wave_length,
@@ -189,11 +189,11 @@ impl Protocol {
         }
     }
 
-    /// Odontoceti
+    /// Blue Bottle
     ///
     /// "BlueBottle: Fast and Robust Blockchains through Subsystem Specialization"
     /// <https://sonnino.com/papers/bluebottle.pdf>
-    pub fn odontoceti(total_stake: Stake, leader_count: NonZeroUsize) -> Self {
+    pub fn blue_bottle(total_stake: Stake, leader_count: NonZeroUsize) -> Self {
         let strong_quorum = 4 * total_stake / 5 + 1;
         let weak_quorum = 2 * total_stake / 5 + 1;
         Self {

--- a/crates/simulator/examples/single.yaml
+++ b/crates/simulator/examples/single.yaml
@@ -29,7 +29,7 @@ replica_parameters:
     fsync: false
   # Consensus protocol variant. Options:
   #   mysticeti                            { leader_count }
-  #   odontoceti                           { leader_count }
+  #   blue-bottle                          { leader_count }
   #   mahi-mahi                            { leader_count, wave_length: 4 | 5 }
   #   nemo-nemo                            { leader_count }
   #   cordial-miners-partially-synchronous


### PR DESCRIPTION
## Summary
- Renames the `Odontoceti` consensus protocol variant to `BlueBottle`, matching the paper title (`BlueBottle: Fast and Robust Blockchains through Subsystem Specialization`).
- Display string becomes `Blue Bottle (N leaders/round)`; serde config key flips from `odontoceti` to `blue-bottle`.
- README, the `single.yaml` simulator example (option comment), and refactor-guardian agent memory updated to match.

## Breaking change
Any external YAML using `protocol: odontoceti` must be updated to `protocol: blue-bottle`. No in-tree runtime/default configs reference this variant — only the example option comment in `crates/simulator/examples/single.yaml`, which is updated here.

## Test plan
- [x] `cargo check --workspace`
- [x] pre-commit (fmt, clippy, cargo-test, typos) passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)