### PR TITLE
docs(readme): rename top heading to "Uncertified DAG Consensus"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="assets/banner.png" alt="Mysticeti" width="720" />
 </p>
 
-# Mysticeti
+# Uncertified DAG Consensus
 
 [![build
 status](https://img.shields.io/github/actions/workflow/status/asonnino/mysticeti/code.yaml?branch=main&logo=github&style=flat-square)](https://github.com/asonnino/mysticeti/actions)


### PR DESCRIPTION
## Summary
- Renames the README top-level heading from `Mysticeti` to `Uncertified DAG Consensus` to better reflect the project's scope across multiple protocol variants.

## Test plan
- [x] Markdown-only change; no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)