### PR TITLE
fix: remove confusing comment in find_support

### DIFF
--- a/crates/consensus/src/base.rs
+++ b/crates/consensus/src/base.rs
@@ -103,9 +103,7 @@ impl BaseCommitter {
 
     /// Find which block is supported at (author, round) by the given block.
     /// Blocks can indirectly reference multiple other blocks at (author, round), but only one
-    /// block at (author, round)  will be supported by the given block. If block A supports B at
-    /// (author, round), it is guaranteed that any processed block by the same author that directly
-    /// or indirectly includes. A will also support B at (author, round).
+    /// block at (author, round) will be supported by the given block.
     fn find_support(
         &self,
         (author, round): (Authority, RoundNumber),


### PR DESCRIPTION
## Summary
- Remove a confusing/incorrect trailing sentence from the `BaseCommitter::find_support` doc comment in `crates/consensus/src/base.rs`.

## Test plan
- [ ] `cargo build`
- [ ] `cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)