### PR TITLE
chore(deps): stop auto-bumping bincode majors and digest 0.11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,14 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # bincode 3.0.0 is a deliberately non-compiling protest release.
+      - dependency-name: "bincode"
+        update-types: ["version-update:semver-major"]
+      # digest 0.11 can't be adopted until blake2 / ed25519-consensus move off the
+      # digest 0.10 `Digest` trait; bumping digest alone yields two incompatible traits.
+      - dependency-name: "digest"
+        versions: ["0.11.x"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
       # digest 0.11 can't be adopted until blake2 / ed25519-consensus move off the
       # digest 0.10 `Digest` trait; bumping digest alone yields two incompatible traits.
       - dependency-name: "digest"
-        versions: ["0.11.x"]
+        versions: ["0.11"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

Two dependabot bumps can never go green; tell dependabot to stop proposing them:

- **bincode `3.0.0`** is a deliberately non-compiling protest release — its `lib.rs` is `compile_error!("https://xkcd.com/2347/")`. The real next major is the 2.x line (a manual API migration). Ignore major bincode bumps.
- **digest `0.11`** can't be adopted until `blake2` / `ed25519-consensus` move off the `digest 0.10` `Digest` trait; bumping `digest` alone produces two incompatible `Digest` traits. Ignore `0.11.x` until the ecosystem catches up.

Lets us close the perpetually-red #145 (bincode) and #147 (digest).

## Test plan

- [x] `dependabot.yml` is valid YAML
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)