### PR TITLE
feat(consensus): explicit Byzantine and crash-fault parameters for Orcaella

### DIFF
--- a/crates/consensus/src/protocol.rs
+++ b/crates/consensus/src/protocol.rs
@@ -30,8 +30,10 @@ pub enum ConsensusProtocol {
     Orcaella {
         #[serde(default = "defaults::default_leader_count")]
         leader_count: NonZeroUsize,
-        /// Crash-fault stake to tolerate; the Byzantine bound `f` is
-        /// derived by saturating `5f + 3c + 1 <= total_stake`.
+        /// Byzantine-fault stake to tolerate.
+        f: Stake,
+        /// Crash-only fault stake to tolerate (on top of `f`); requires
+        /// `5f + 3c + 1 <= total_stake`.
         c: Stake,
     },
     MahiMahi {
@@ -78,31 +80,35 @@ impl Default for ConsensusProtocol {
 }
 
 impl fmt::Display for ConsensusProtocol {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::CordialMinersPartiallySynchronous => {
-                write!(f, "Cordial Miners (PS)")
+                write!(fmt, "Cordial Miners (PS)")
             }
-            Self::CordialMinersAsynchronous => write!(f, "Cordial Miners (Async)"),
+            Self::CordialMinersAsynchronous => write!(fmt, "Cordial Miners (Async)"),
             Self::Mysticeti { leader_count } => {
-                write!(f, "Mysticeti ({} leaders/round)", leader_count)
+                write!(fmt, "Mysticeti ({} leaders/round)", leader_count)
             }
             Self::BlueBottle { leader_count } => {
-                write!(f, "Blue Bottle ({} leaders/round)", leader_count)
+                write!(fmt, "Blue Bottle ({} leaders/round)", leader_count)
             }
-            Self::Orcaella { leader_count, c } => {
-                write!(f, "Orcaella ({} leaders/round, c={})", leader_count, c)
+            Self::Orcaella { leader_count, f, c } => {
+                write!(
+                    fmt,
+                    "Orcaella ({} leaders/round, f={f}, c={c})",
+                    leader_count
+                )
             }
             Self::MahiMahi {
                 leader_count,
                 wave_length,
             } => write!(
-                f,
+                fmt,
                 "Mahi-Mahi ({} leaders/round, wave length {})",
                 leader_count, wave_length
             ),
             Self::NemoNemo { leader_count } => {
-                write!(f, "Nemo-Nemo ({} leaders/round)", leader_count)
+                write!(fmt, "Nemo-Nemo ({} leaders/round)", leader_count)
             }
         }
     }
@@ -137,7 +143,9 @@ impl ConsensusProtocol {
             Self::CordialMinersAsynchronous => Protocol::cordial_miners_asynchronous(total_stake),
             Self::Mysticeti { leader_count } => Protocol::mysticeti(total_stake, leader_count),
             Self::BlueBottle { leader_count } => Protocol::blue_bottle(total_stake, leader_count),
-            Self::Orcaella { leader_count, c } => Protocol::orcaella(total_stake, c, leader_count)?,
+            Self::Orcaella { leader_count, f, c } => {
+                Protocol::orcaella(total_stake, f, c, leader_count)?
+            }
             Self::MahiMahi {
                 leader_count,
                 wave_length,
@@ -151,18 +159,33 @@ impl ConsensusProtocol {
 #[cfg(any(test, feature = "test-utils"))]
 impl ConsensusProtocol {
     /// All protocols at the baseline matrix configuration used by the
-    /// per-scenario integration tests, swept over `leader_counts`. Multi-leader-
-    /// aware protocols (Mysticeti, BlueBottle, NemoNemo, Orcaella with `c=0`,
-    /// Mahi-Mahi for `wave_length ∈ {4, 5}`) emit one variant per leader count;
-    /// Cordial Miners variants are leader-count-agnostic and emit once.
-    pub fn all_for_test(leader_counts: &[usize]) -> Vec<Self> {
+    /// per-scenario integration tests, swept over `leader_counts`.
+    pub fn all_for_test(n: usize, leader_counts: &[usize]) -> Vec<Self> {
         let mut variants = Vec::new();
         for &l in leader_counts {
             let leader_count = NonZeroUsize::new(l).expect("leader_count must be non-zero");
             variants.push(Self::Mysticeti { leader_count });
             variants.push(Self::BlueBottle { leader_count });
             variants.push(Self::NemoNemo { leader_count });
-            variants.push(Self::Orcaella { leader_count, c: 0 });
+            variants.push(Self::Orcaella {
+                leader_count,
+                f: 0,
+                c: 1,
+            });
+            if n >= 6 {
+                variants.push(Self::Orcaella {
+                    leader_count,
+                    f: 1,
+                    c: 0,
+                });
+            }
+            if n >= 9 {
+                variants.push(Self::Orcaella {
+                    leader_count,
+                    f: 1,
+                    c: 1,
+                });
+            }
             variants.push(Self::MahiMahi {
                 leader_count,
                 wave_length: 4,
@@ -181,8 +204,8 @@ impl ConsensusProtocol {
 /// Errors that can arise when building a [`Protocol`] from a [`ConsensusProtocol`].
 #[derive(Debug, thiserror::Error)]
 pub enum ProtocolError {
-    #[error("Orcaella requires 3c + 1 <= n (n={n}, c={c})")]
-    OrcaellaCrashStakeTooLarge { n: Stake, c: Stake },
+    #[error("Orcaella requires 5f + 3c + 1 <= n (n={n}, f={f}, c={c})")]
+    OrcaellaFaultBoundViolated { n: Stake, f: Stake, c: Stake },
     #[error("Mahi-Mahi requires wave_length in {{4, 5}}, got {wave_length}")]
     MahiMahiInvalidWaveLength { wave_length: RoundNumber },
     #[error("leader_count ({leader_count}) exceeds committee size ({committee_size})")]
@@ -292,19 +315,22 @@ impl Protocol {
     /// <TBD>
     pub fn orcaella(
         total_stake: Stake,
+        f: Stake,
         c: Stake,
         leader_count: NonZeroUsize,
     ) -> Result<Self, ProtocolError> {
-        if 3 * c >= total_stake {
-            return Err(ProtocolError::OrcaellaCrashStakeTooLarge { n: total_stake, c });
+        if 5 * f + 3 * c + 1 > total_stake {
+            return Err(ProtocolError::OrcaellaFaultBoundViolated {
+                n: total_stake,
+                f,
+                c,
+            });
         }
 
-        let strong_quorum = (4 * total_stake - 2 * c) / 5 + 1;
-        let weak_quorum = (2 * total_stake - c) / 5 + 1;
         Ok(Self {
-            direct_commit_quorum: strong_quorum,
-            direct_skip_quorum: strong_quorum,
-            anchor_link_size: weak_quorum,
+            direct_commit_quorum: total_stake - f - c,
+            direct_skip_quorum: 4 * f + 2 * c + 1,
+            anchor_link_size: total_stake - 3 * f - 2 * c,
             wave_length: 2,
             leader_count,
             pipeline: true,

--- a/crates/consensus/tests/direct_commit_late_call_tests.rs
+++ b/crates/consensus/tests/direct_commit_late_call_tests.rs
@@ -21,14 +21,14 @@ fn direct_commit_late_call_n4() {
 
 #[test]
 #[tracing_test::traced_test]
-fn direct_commit_late_call_n10() {
-    run_for_size(10);
+fn direct_commit_late_call_n20() {
+    run_for_size(20);
 }
 
 fn run_for_size(n: usize) {
     let committee = committee(n);
     let leader_counts = [1, 2, 2 * n / 3 + 1, n];
-    for spec in ConsensusProtocol::all_for_test(&leader_counts) {
+    for spec in ConsensusProtocol::all_for_test(n, &leader_counts) {
         run(&spec, &committee);
     }
 }

--- a/crates/consensus/tests/direct_commit_partial_round_tests.rs
+++ b/crates/consensus/tests/direct_commit_partial_round_tests.rs
@@ -28,14 +28,14 @@ fn direct_commit_partial_round_n4() {
 
 #[test]
 #[tracing_test::traced_test]
-fn direct_commit_partial_round_n10() {
-    run_for_size(10);
+fn direct_commit_partial_round_n20() {
+    run_for_size(20);
 }
 
 fn run_for_size(n: usize) {
     let committee = committee(n);
     let leader_counts = [1, 2, 2 * n / 3 + 1, n];
-    for spec in ConsensusProtocol::all_for_test(&leader_counts) {
+    for spec in ConsensusProtocol::all_for_test(n, &leader_counts) {
         run(&spec, &committee);
     }
 }

--- a/crates/consensus/tests/direct_commit_tests.rs
+++ b/crates/consensus/tests/direct_commit_tests.rs
@@ -21,14 +21,14 @@ fn direct_commit_n4() {
 
 #[test]
 #[tracing_test::traced_test]
-fn direct_commit_n10() {
-    run_for_size(10);
+fn direct_commit_n20() {
+    run_for_size(20);
 }
 
 fn run_for_size(n: usize) {
     let committee = committee(n);
     let leader_counts = [1, 2, 2 * n / 3 + 1, n];
-    for spec in ConsensusProtocol::all_for_test(&leader_counts) {
+    for spec in ConsensusProtocol::all_for_test(n, &leader_counts) {
         run(&spec, &committee);
     }
 }

--- a/crates/consensus/tests/direct_skip_tests.rs
+++ b/crates/consensus/tests/direct_skip_tests.rs
@@ -21,14 +21,14 @@ fn direct_skip_n4() {
 
 #[test]
 #[tracing_test::traced_test]
-fn direct_skip_n10() {
-    run_for_size(10);
+fn direct_skip_n20() {
+    run_for_size(20);
 }
 
 fn run_for_size(n: usize) {
     let committee = committee(n);
     let leader_counts = [1, 2, 2 * n / 3 + 1, n];
-    for spec in ConsensusProtocol::all_for_test(&leader_counts) {
+    for spec in ConsensusProtocol::all_for_test(n, &leader_counts) {
         run(&spec, &committee);
     }
 }

--- a/crates/consensus/tests/idempotence_tests.rs
+++ b/crates/consensus/tests/idempotence_tests.rs
@@ -20,14 +20,14 @@ fn idempotence_n4() {
 
 #[test]
 #[tracing_test::traced_test]
-fn idempotence_n10() {
-    run_for_size(10);
+fn idempotence_n20() {
+    run_for_size(20);
 }
 
 fn run_for_size(n: usize) {
     let committee = committee(n);
     let leader_counts = [1, 2, 2 * n / 3 + 1, n];
-    for spec in ConsensusProtocol::all_for_test(&leader_counts) {
+    for spec in ConsensusProtocol::all_for_test(n, &leader_counts) {
         run(&spec, &committee);
     }
 }

--- a/crates/consensus/tests/indirect_commit_tests.rs
+++ b/crates/consensus/tests/indirect_commit_tests.rs
@@ -35,14 +35,14 @@ fn indirect_commit_n4() {
 
 #[test]
 #[tracing_test::traced_test]
-fn indirect_commit_n10() {
-    run_for_size(10);
+fn indirect_commit_n20() {
+    run_for_size(20);
 }
 
 fn run_for_size(n: usize) {
     let committee = committee(n);
     let leader_counts = [1, 2, 2 * n / 3 + 1, n];
-    for spec in ConsensusProtocol::all_for_test(&leader_counts) {
+    for spec in ConsensusProtocol::all_for_test(n, &leader_counts) {
         run(&spec, &committee);
     }
 }

--- a/crates/consensus/tests/indirect_skip_tests.rs
+++ b/crates/consensus/tests/indirect_skip_tests.rs
@@ -33,14 +33,14 @@ fn indirect_skip_n4() {
 
 #[test]
 #[tracing_test::traced_test]
-fn indirect_skip_n10() {
-    run_for_size(10);
+fn indirect_skip_n20() {
+    run_for_size(20);
 }
 
 fn run_for_size(n: usize) {
     let committee = committee(n);
     let leader_counts = [1, 2, 2 * n / 3 + 1, n];
-    for spec in ConsensusProtocol::all_for_test(&leader_counts) {
+    for spec in ConsensusProtocol::all_for_test(n, &leader_counts) {
         run(&spec, &committee);
     }
 }

--- a/crates/consensus/tests/multiple_direct_commit_tests.rs
+++ b/crates/consensus/tests/multiple_direct_commit_tests.rs
@@ -23,14 +23,14 @@ fn multiple_direct_commit_n4() {
 
 #[test]
 #[tracing_test::traced_test]
-fn multiple_direct_commit_n10() {
-    run_for_size(10);
+fn multiple_direct_commit_n20() {
+    run_for_size(20);
 }
 
 fn run_for_size(n: usize) {
     let committee = committee(n);
     let leader_counts = [1, 2, 2 * n / 3 + 1, n];
-    for spec in ConsensusProtocol::all_for_test(&leader_counts) {
+    for spec in ConsensusProtocol::all_for_test(n, &leader_counts) {
         run(&spec, &committee);
     }
 }

--- a/crates/consensus/tests/no_genesis_commit_tests.rs
+++ b/crates/consensus/tests/no_genesis_commit_tests.rs
@@ -20,14 +20,14 @@ fn no_genesis_commit_n4() {
 
 #[test]
 #[tracing_test::traced_test]
-fn no_genesis_commit_n10() {
-    run_for_size(10);
+fn no_genesis_commit_n20() {
+    run_for_size(20);
 }
 
 fn run_for_size(n: usize) {
     let committee = committee(n);
     let leader_counts = [1, 2, 2 * n / 3 + 1, n];
-    for spec in ConsensusProtocol::all_for_test(&leader_counts) {
+    for spec in ConsensusProtocol::all_for_test(n, &leader_counts) {
         run(&spec, &committee);
     }
 }

--- a/crates/consensus/tests/no_leader_tests.rs
+++ b/crates/consensus/tests/no_leader_tests.rs
@@ -21,14 +21,14 @@ fn no_leader_n4() {
 
 #[test]
 #[tracing_test::traced_test]
-fn no_leader_n10() {
-    run_for_size(10);
+fn no_leader_n20() {
+    run_for_size(20);
 }
 
 fn run_for_size(n: usize) {
     let committee = committee(n);
     let leader_counts = [1, 2, 2 * n / 3 + 1, n];
-    for spec in ConsensusProtocol::all_for_test(&leader_counts) {
+    for spec in ConsensusProtocol::all_for_test(n, &leader_counts) {
         run(&spec, &committee);
     }
 }

--- a/crates/consensus/tests/trailing_skip_not_re_yielded_tests.rs
+++ b/crates/consensus/tests/trailing_skip_not_re_yielded_tests.rs
@@ -24,14 +24,14 @@ fn trailing_skip_not_re_yielded_n4() {
 
 #[test]
 #[tracing_test::traced_test]
-fn trailing_skip_not_re_yielded_n10() {
-    run_for_size(10);
+fn trailing_skip_not_re_yielded_n20() {
+    run_for_size(20);
 }
 
 fn run_for_size(n: usize) {
     let committee = committee(n);
     let leader_counts = [1, 2, 2 * n / 3 + 1, n];
-    for spec in ConsensusProtocol::all_for_test(&leader_counts) {
+    for spec in ConsensusProtocol::all_for_test(n, &leader_counts) {
         run(&spec, &committee);
     }
 }

--- a/crates/consensus/tests/undecided_tests.rs
+++ b/crates/consensus/tests/undecided_tests.rs
@@ -25,14 +25,14 @@ fn undecided_n4() {
 
 #[test]
 #[tracing_test::traced_test]
-fn undecided_n10() {
-    run_for_size(10);
+fn undecided_n20() {
+    run_for_size(20);
 }
 
 fn run_for_size(n: usize) {
     let committee = committee(n);
     let leader_counts = [1, 2, 2 * n / 3 + 1, n];
-    for spec in ConsensusProtocol::all_for_test(&leader_counts) {
+    for spec in ConsensusProtocol::all_for_test(n, &leader_counts) {
         run(&spec, &committee);
     }
 }

--- a/crates/simulator/examples/single.yaml
+++ b/crates/simulator/examples/single.yaml
@@ -30,7 +30,7 @@ replica_parameters:
   # Consensus protocol variant. Options:
   #   mysticeti                            { leader_count }
   #   blue-bottle                          { leader_count }
-  #   orcaella                             { leader_count, c }
+  #   orcaella                             { leader_count, f, c }
   #   mahi-mahi                            { leader_count, wave_length: 4 | 5 }
   #   nemo-nemo                            { leader_count }
   #   cordial-miners-partially-synchronous


### PR DESCRIPTION
## Summary

- Replaces the implicit single-parameter `c` in `ConsensusProtocol::Orcaella` with explicit `f` (Byzantine-only faults) and `c` (crash-only faults on top of `f`), gated by the feasibility condition `5f + 3c + 1 <= n`
- Derives quorum thresholds directly from `(n, f, c)`: commit = `n−f−c`, skip = `4f+2c+1`, anchor = `n−3f−2c`; these reduce to the classic CFT quorum at `f=0` and recover Blue Bottle's thresholds at `c=0`
- Extends the Orcaella test matrix via a new `n` parameter on `all_for_test`: pure-BFT `(f=1,c=0)` for n≥6 and mixed `(f=1,c=1)` for n≥9; bumps the larger test committee from n=10 to n=20

## Test plan

- [ ] `cargo test -p consensus` — all 12 integration test scenarios pass at n=4 and n=20 (now covering 3 Orcaella fault configurations at n=20)
- [ ] `cargo clippy --workspace --all-targets` — clean
- [ ] `cargo fmt --check` — clean
- [ ] Pre-commit hook (fmt + clippy + full test suite) passed on commit

🤖 Generated with [Claude Code](https://claude.ai/claude-code)