### PR TITLE
test(simulator): Orcaella simulation test suite

### DIFF
--- a/crates/consensus/src/protocol.rs
+++ b/crates/consensus/src/protocol.rs
@@ -33,7 +33,7 @@ pub enum ConsensusProtocol {
         /// Byzantine-fault stake to tolerate.
         f: Stake,
         /// Crash-only fault stake to tolerate (on top of `f`); requires
-        /// `5f + 3c + 1 <= total_stake`.
+        /// `n >= 5f+3c+1` for `f > 0`, or `n >= 2c+1` for `f = 0`.
         c: Stake,
     },
     MahiMahi {
@@ -204,7 +204,7 @@ impl ConsensusProtocol {
 /// Errors that can arise when building a [`Protocol`] from a [`ConsensusProtocol`].
 #[derive(Debug, thiserror::Error)]
 pub enum ProtocolError {
-    #[error("Orcaella requires 5f + 3c + 1 <= n (n={n}, f={f}, c={c})")]
+    #[error("Orcaella fault bound violated (n={n}, f={f}, c={c})")]
     OrcaellaFaultBoundViolated { n: Stake, f: Stake, c: Stake },
     #[error("Mahi-Mahi requires wave_length in {{4, 5}}, got {wave_length}")]
     MahiMahiInvalidWaveLength { wave_length: RoundNumber },
@@ -319,7 +319,8 @@ impl Protocol {
         c: Stake,
         leader_count: NonZeroUsize,
     ) -> Result<Self, ProtocolError> {
-        if 5 * f + 3 * c + 1 > total_stake {
+        let min_n = if f == 0 { 2 * c + 1 } else { 5 * f + 3 * c + 1 };
+        if min_n > total_stake {
             return Err(ProtocolError::OrcaellaFaultBoundViolated {
                 n: total_stake,
                 f,

--- a/crates/simulator/tests/orcaella.rs
+++ b/crates/simulator/tests/orcaella.rs
@@ -2,11 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Orcaella simulation tests.
-//!
-//! Covers happy-path, crash faults (OneDown), partition boundary cases,
-//! non-optimal (k>0) committee sizes, multi-leader, and feasibility errors.
-//! Byzantine equivocation is not injectable with the current simulator and
-//! is out of scope here.
 
 use std::num::NonZeroUsize;
 
@@ -38,11 +33,12 @@ fn assert_progress(result: &RunResult<SimulationConfig>, min_commits: u64) {
 }
 
 #[test]
-fn happy_path_crash_only_n4() {
-    // n=4, f=0, c=1 → commit=3, skip=3, anchor=2 (tight)
+fn happy_path_crash_only_n3() {
+    // n=3, f=0, c=1 → commit=2, skip=3, anchor=1 — CFT minimum (n=2c+1)
+    // Direct skip is disabled (s=n); progress relies on indirect commit.
     assert_progress(
         &run(SimulationConfig {
-            committee_size: 4,
+            committee_size: 3,
             duration_secs: 30,
             replica_parameters: ReplicaParameters {
                 consensus: orcaella(0, 1, 2),
@@ -89,11 +85,11 @@ fn happy_path_mixed_n9() {
 }
 
 #[test]
-fn crash_one_node_n4() {
-    // commit=3, 3 active nodes — exactly at threshold
+fn crash_one_node_n3() {
+    // n=3, f=0, c=1: crash 1 node → 2 active == commit threshold
     assert_progress(
         &run(SimulationConfig {
-            committee_size: 4,
+            committee_size: 3,
             topology: NetworkTopology::OneDown(0),
             duration_secs: 30,
             replica_parameters: ReplicaParameters {
@@ -261,10 +257,16 @@ fn multi_leader_4_n9() {
 
 #[test]
 fn infeasible_params_rejected() {
-    // n=4, f=1, c=0: 5*1 + 3*0 + 1 = 6 > 4 — must be rejected
+    // BFT: n=4, f=1, c=0 needs n >= 5*1+3*0+1 = 6 — rejected
     let result = Protocol::orcaella(4, 1, 0, NonZeroUsize::new(1).unwrap());
     assert!(matches!(
         result,
         Err(ProtocolError::OrcaellaFaultBoundViolated { n: 4, f: 1, c: 0 })
+    ));
+    // CFT: n=2, f=0, c=1 needs n >= 2*1+1 = 3 — rejected
+    let result = Protocol::orcaella(2, 0, 1, NonZeroUsize::new(1).unwrap());
+    assert!(matches!(
+        result,
+        Err(ProtocolError::OrcaellaFaultBoundViolated { n: 2, f: 0, c: 1 })
     ));
 }

--- a/crates/simulator/tests/orcaella.rs
+++ b/crates/simulator/tests/orcaella.rs
@@ -73,7 +73,7 @@ fn happy_path_bft_n6() {
 
 #[test]
 fn happy_path_mixed_n9() {
-    // n=9, f=1, c=1 → commit=7, skip=7, anchor=5 (tight)
+    // n=9, f=1, c=1 → commit=7, skip=7, anchor=4 (tight)
     assert_progress(
         &run(SimulationConfig {
             committee_size: 9,

--- a/crates/simulator/tests/orcaella.rs
+++ b/crates/simulator/tests/orcaella.rs
@@ -1,0 +1,236 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Orcaella simulation tests.
+//!
+//! Covers happy-path, crash faults (OneDown), partition boundary cases,
+//! non-optimal (k>0) committee sizes, multi-leader, and feasibility errors.
+//! Byzantine equivocation is not injectable with the current simulator and
+//! is out of scope here.
+
+use std::num::NonZeroUsize;
+
+use consensus::protocol::{ConsensusProtocol, Protocol, ProtocolError};
+use replica::config::ReplicaParameters;
+use replica::result::Outcome;
+use simulator::{NetworkTopology, SimulationConfig, SimulationRunner};
+
+fn orcaella(f: u64, c: u64, leader_count: usize) -> ConsensusProtocol {
+    ConsensusProtocol::Orcaella {
+        leader_count: NonZeroUsize::new(leader_count).unwrap(),
+        f,
+        c,
+    }
+}
+
+fn run(config: SimulationConfig) -> Outcome {
+    SimulationRunner::new(config).run().unwrap().outcome
+}
+
+#[test]
+fn happy_path_crash_only_n4() {
+    // n=4, f=0, c=1 → commit=3, skip=3, anchor=2 (tight)
+    let outcome = run(SimulationConfig {
+        committee_size: 4,
+        duration_secs: 30,
+        replica_parameters: ReplicaParameters {
+            consensus: orcaella(0, 1, 2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    assert_eq!(outcome, Outcome::Pass);
+}
+
+#[test]
+fn happy_path_bft_n6() {
+    // n=6, f=1, c=0 → commit=5, skip=5, anchor=3 (tight)
+    let outcome = run(SimulationConfig {
+        committee_size: 6,
+        duration_secs: 30,
+        replica_parameters: ReplicaParameters {
+            consensus: orcaella(1, 0, 2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    assert_eq!(outcome, Outcome::Pass);
+}
+
+#[test]
+fn happy_path_mixed_n9() {
+    // n=9, f=1, c=1 → commit=7, skip=7, anchor=5 (tight)
+    let outcome = run(SimulationConfig {
+        committee_size: 9,
+        duration_secs: 30,
+        replica_parameters: ReplicaParameters {
+            consensus: orcaella(1, 1, 2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    assert_eq!(outcome, Outcome::Pass);
+}
+
+#[test]
+fn crash_one_node_n4() {
+    // commit=3, 3 active nodes — exactly at threshold
+    let outcome = run(SimulationConfig {
+        committee_size: 4,
+        topology: NetworkTopology::OneDown(0),
+        duration_secs: 30,
+        replica_parameters: ReplicaParameters {
+            consensus: orcaella(0, 1, 2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    assert_eq!(outcome, Outcome::Pass);
+}
+
+#[test]
+fn crash_one_node_n6() {
+    // commit=5, 5 active nodes — exactly at threshold
+    let outcome = run(SimulationConfig {
+        committee_size: 6,
+        topology: NetworkTopology::OneDown(0),
+        duration_secs: 30,
+        replica_parameters: ReplicaParameters {
+            consensus: orcaella(1, 0, 2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    assert_eq!(outcome, Outcome::Pass);
+}
+
+#[test]
+fn crash_one_node_n9() {
+    // commit=7, 8 active nodes — one node to spare
+    let outcome = run(SimulationConfig {
+        committee_size: 9,
+        topology: NetworkTopology::OneDown(0),
+        duration_secs: 30,
+        replica_parameters: ReplicaParameters {
+            consensus: orcaella(1, 1, 2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    assert_eq!(outcome, Outcome::Pass);
+}
+
+#[test]
+fn partition_at_quorum_n9() {
+    // Majority has exactly 7 nodes == commit threshold — just barely makes progress.
+    let outcome = run(SimulationConfig {
+        committee_size: 9,
+        topology: NetworkTopology::Partition(vec![vec![0, 1], vec![2, 3, 4, 5, 6, 7, 8]]),
+        duration_secs: 40,
+        replica_parameters: ReplicaParameters {
+            consensus: orcaella(1, 1, 2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    assert_ne!(outcome, Outcome::Diverged);
+}
+
+#[test]
+fn partition_below_quorum_n9() {
+    // Majority has 6 nodes < commit=7 — neither side can commit; safety must hold.
+    let outcome = run(SimulationConfig {
+        committee_size: 9,
+        topology: NetworkTopology::Partition(vec![vec![0, 1, 2], vec![3, 4, 5, 6, 7, 8]]),
+        duration_secs: 20,
+        replica_parameters: ReplicaParameters {
+            consensus: orcaella(1, 1, 2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    assert_ne!(outcome, Outcome::Diverged);
+}
+
+#[test]
+fn non_optimal_crash_only_n20() {
+    // n=20, f=0, c=1 → commit=19, skip=3, anchor=18 (k=16)
+    let outcome = run(SimulationConfig {
+        committee_size: 20,
+        duration_secs: 40,
+        replica_parameters: ReplicaParameters {
+            consensus: orcaella(0, 1, 2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    assert_eq!(outcome, Outcome::Pass);
+}
+
+#[test]
+fn non_optimal_bft_n20() {
+    // n=20, f=1, c=0 → commit=19, skip=5, anchor=17 (k=14)
+    let outcome = run(SimulationConfig {
+        committee_size: 20,
+        duration_secs: 40,
+        replica_parameters: ReplicaParameters {
+            consensus: orcaella(1, 0, 2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    assert_eq!(outcome, Outcome::Pass);
+}
+
+#[test]
+fn non_optimal_mixed_n20() {
+    // n=20, f=1, c=1 → commit=18, skip=7, anchor=15 (k=11)
+    let outcome = run(SimulationConfig {
+        committee_size: 20,
+        duration_secs: 40,
+        replica_parameters: ReplicaParameters {
+            consensus: orcaella(1, 1, 2),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    assert_eq!(outcome, Outcome::Pass);
+}
+
+#[test]
+fn multi_leader_1_n9() {
+    let outcome = run(SimulationConfig {
+        committee_size: 9,
+        duration_secs: 30,
+        replica_parameters: ReplicaParameters {
+            consensus: orcaella(1, 1, 1),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    assert_eq!(outcome, Outcome::Pass);
+}
+
+#[test]
+fn multi_leader_4_n9() {
+    let outcome = run(SimulationConfig {
+        committee_size: 9,
+        duration_secs: 30,
+        replica_parameters: ReplicaParameters {
+            consensus: orcaella(1, 1, 4),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+    assert_eq!(outcome, Outcome::Pass);
+}
+
+#[test]
+fn infeasible_params_rejected() {
+    // n=4, f=1, c=0: 5*1 + 3*0 + 1 = 6 > 4 — must be rejected
+    let result = Protocol::orcaella(4, 1, 0, NonZeroUsize::new(1).unwrap());
+    assert!(matches!(
+        result,
+        Err(ProtocolError::OrcaellaFaultBoundViolated { n: 4, f: 1, c: 0 })
+    ));
+}

--- a/crates/simulator/tests/orcaella.rs
+++ b/crates/simulator/tests/orcaella.rs
@@ -145,22 +145,24 @@ fn crash_one_node_n9() {
 #[test]
 fn partition_at_quorum_n9() {
     // Majority has exactly 7 nodes == commit threshold — just barely makes progress.
-    let result = run(SimulationConfig {
-        committee_size: 9,
-        topology: NetworkTopology::Partition(vec![vec![0, 1], vec![2, 3, 4, 5, 6, 7, 8]]),
-        duration_secs: 40,
-        replica_parameters: ReplicaParameters {
-            consensus: orcaella(1, 1, 2),
+    assert_progress(
+        &run(SimulationConfig {
+            committee_size: 9,
+            topology: NetworkTopology::Partition(vec![vec![0, 1], vec![2, 3, 4, 5, 6, 7, 8]]),
+            duration_secs: 40,
+            replica_parameters: ReplicaParameters {
+                consensus: orcaella(1, 1, 2),
+                ..Default::default()
+            },
             ..Default::default()
-        },
-        ..Default::default()
-    });
-    assert_ne!(result.outcome, Outcome::Diverged);
+        }),
+        10,
+    );
 }
 
 #[test]
 fn partition_below_quorum_n9() {
-    // Majority has 6 nodes < commit=7 — neither side can commit; safety must hold.
+    // Majority has 6 nodes < commit=7 — neither side can commit.
     let result = run(SimulationConfig {
         committee_size: 9,
         topology: NetworkTopology::Partition(vec![vec![0, 1, 2], vec![3, 4, 5, 6, 7, 8]]),
@@ -171,7 +173,7 @@ fn partition_below_quorum_n9() {
         },
         ..Default::default()
     });
-    assert_ne!(result.outcome, Outcome::Diverged);
+    assert_eq!(result.outcome, Outcome::NoProgress);
 }
 
 #[test]

--- a/crates/simulator/tests/orcaella.rs
+++ b/crates/simulator/tests/orcaella.rs
@@ -11,8 +11,9 @@
 use std::num::NonZeroUsize;
 
 use consensus::protocol::{ConsensusProtocol, Protocol, ProtocolError};
+use dag::metrics::SnapshotAggregate;
 use replica::config::ReplicaParameters;
-use replica::result::Outcome;
+use replica::result::{Outcome, RunResult};
 use simulator::{NetworkTopology, SimulationConfig, SimulationRunner};
 
 fn orcaella(f: u64, c: u64, leader_count: usize) -> ConsensusProtocol {
@@ -23,107 +24,128 @@ fn orcaella(f: u64, c: u64, leader_count: usize) -> ConsensusProtocol {
     }
 }
 
-fn run(config: SimulationConfig) -> Outcome {
-    SimulationRunner::new(config).run().unwrap().outcome
+fn run(config: SimulationConfig) -> RunResult<SimulationConfig> {
+    SimulationRunner::new(config).run().unwrap()
+}
+
+fn assert_progress(result: &RunResult<SimulationConfig>, min_commits: u64) {
+    assert_eq!(result.outcome, Outcome::Pass);
+    let commits = SnapshotAggregate::new(&result.metrics).max_committed_leaders();
+    assert!(
+        commits >= min_commits,
+        "expected >= {min_commits} committed leaders, got {commits}"
+    );
 }
 
 #[test]
 fn happy_path_crash_only_n4() {
     // n=4, f=0, c=1 → commit=3, skip=3, anchor=2 (tight)
-    let outcome = run(SimulationConfig {
-        committee_size: 4,
-        duration_secs: 30,
-        replica_parameters: ReplicaParameters {
-            consensus: orcaella(0, 1, 2),
+    assert_progress(
+        &run(SimulationConfig {
+            committee_size: 4,
+            duration_secs: 30,
+            replica_parameters: ReplicaParameters {
+                consensus: orcaella(0, 1, 2),
+                ..Default::default()
+            },
             ..Default::default()
-        },
-        ..Default::default()
-    });
-    assert_eq!(outcome, Outcome::Pass);
+        }),
+        10,
+    );
 }
 
 #[test]
 fn happy_path_bft_n6() {
     // n=6, f=1, c=0 → commit=5, skip=5, anchor=3 (tight)
-    let outcome = run(SimulationConfig {
-        committee_size: 6,
-        duration_secs: 30,
-        replica_parameters: ReplicaParameters {
-            consensus: orcaella(1, 0, 2),
+    assert_progress(
+        &run(SimulationConfig {
+            committee_size: 6,
+            duration_secs: 30,
+            replica_parameters: ReplicaParameters {
+                consensus: orcaella(1, 0, 2),
+                ..Default::default()
+            },
             ..Default::default()
-        },
-        ..Default::default()
-    });
-    assert_eq!(outcome, Outcome::Pass);
+        }),
+        10,
+    );
 }
 
 #[test]
 fn happy_path_mixed_n9() {
     // n=9, f=1, c=1 → commit=7, skip=7, anchor=5 (tight)
-    let outcome = run(SimulationConfig {
-        committee_size: 9,
-        duration_secs: 30,
-        replica_parameters: ReplicaParameters {
-            consensus: orcaella(1, 1, 2),
+    assert_progress(
+        &run(SimulationConfig {
+            committee_size: 9,
+            duration_secs: 30,
+            replica_parameters: ReplicaParameters {
+                consensus: orcaella(1, 1, 2),
+                ..Default::default()
+            },
             ..Default::default()
-        },
-        ..Default::default()
-    });
-    assert_eq!(outcome, Outcome::Pass);
+        }),
+        10,
+    );
 }
 
 #[test]
 fn crash_one_node_n4() {
     // commit=3, 3 active nodes — exactly at threshold
-    let outcome = run(SimulationConfig {
-        committee_size: 4,
-        topology: NetworkTopology::OneDown(0),
-        duration_secs: 30,
-        replica_parameters: ReplicaParameters {
-            consensus: orcaella(0, 1, 2),
+    assert_progress(
+        &run(SimulationConfig {
+            committee_size: 4,
+            topology: NetworkTopology::OneDown(0),
+            duration_secs: 30,
+            replica_parameters: ReplicaParameters {
+                consensus: orcaella(0, 1, 2),
+                ..Default::default()
+            },
             ..Default::default()
-        },
-        ..Default::default()
-    });
-    assert_eq!(outcome, Outcome::Pass);
+        }),
+        10,
+    );
 }
 
 #[test]
 fn crash_one_node_n6() {
     // commit=5, 5 active nodes — exactly at threshold
-    let outcome = run(SimulationConfig {
-        committee_size: 6,
-        topology: NetworkTopology::OneDown(0),
-        duration_secs: 30,
-        replica_parameters: ReplicaParameters {
-            consensus: orcaella(1, 0, 2),
+    assert_progress(
+        &run(SimulationConfig {
+            committee_size: 6,
+            topology: NetworkTopology::OneDown(0),
+            duration_secs: 30,
+            replica_parameters: ReplicaParameters {
+                consensus: orcaella(1, 0, 2),
+                ..Default::default()
+            },
             ..Default::default()
-        },
-        ..Default::default()
-    });
-    assert_eq!(outcome, Outcome::Pass);
+        }),
+        10,
+    );
 }
 
 #[test]
 fn crash_one_node_n9() {
     // commit=7, 8 active nodes — one node to spare
-    let outcome = run(SimulationConfig {
-        committee_size: 9,
-        topology: NetworkTopology::OneDown(0),
-        duration_secs: 30,
-        replica_parameters: ReplicaParameters {
-            consensus: orcaella(1, 1, 2),
+    assert_progress(
+        &run(SimulationConfig {
+            committee_size: 9,
+            topology: NetworkTopology::OneDown(0),
+            duration_secs: 30,
+            replica_parameters: ReplicaParameters {
+                consensus: orcaella(1, 1, 2),
+                ..Default::default()
+            },
             ..Default::default()
-        },
-        ..Default::default()
-    });
-    assert_eq!(outcome, Outcome::Pass);
+        }),
+        10,
+    );
 }
 
 #[test]
 fn partition_at_quorum_n9() {
     // Majority has exactly 7 nodes == commit threshold — just barely makes progress.
-    let outcome = run(SimulationConfig {
+    let result = run(SimulationConfig {
         committee_size: 9,
         topology: NetworkTopology::Partition(vec![vec![0, 1], vec![2, 3, 4, 5, 6, 7, 8]]),
         duration_secs: 40,
@@ -133,13 +155,13 @@ fn partition_at_quorum_n9() {
         },
         ..Default::default()
     });
-    assert_ne!(outcome, Outcome::Diverged);
+    assert_ne!(result.outcome, Outcome::Diverged);
 }
 
 #[test]
 fn partition_below_quorum_n9() {
     // Majority has 6 nodes < commit=7 — neither side can commit; safety must hold.
-    let outcome = run(SimulationConfig {
+    let result = run(SimulationConfig {
         committee_size: 9,
         topology: NetworkTopology::Partition(vec![vec![0, 1, 2], vec![3, 4, 5, 6, 7, 8]]),
         duration_secs: 20,
@@ -149,80 +171,90 @@ fn partition_below_quorum_n9() {
         },
         ..Default::default()
     });
-    assert_ne!(outcome, Outcome::Diverged);
+    assert_ne!(result.outcome, Outcome::Diverged);
 }
 
 #[test]
 fn non_optimal_crash_only_n20() {
     // n=20, f=0, c=1 → commit=19, skip=3, anchor=18 (k=16)
-    let outcome = run(SimulationConfig {
-        committee_size: 20,
-        duration_secs: 40,
-        replica_parameters: ReplicaParameters {
-            consensus: orcaella(0, 1, 2),
+    assert_progress(
+        &run(SimulationConfig {
+            committee_size: 20,
+            duration_secs: 40,
+            replica_parameters: ReplicaParameters {
+                consensus: orcaella(0, 1, 2),
+                ..Default::default()
+            },
             ..Default::default()
-        },
-        ..Default::default()
-    });
-    assert_eq!(outcome, Outcome::Pass);
+        }),
+        15,
+    );
 }
 
 #[test]
 fn non_optimal_bft_n20() {
     // n=20, f=1, c=0 → commit=19, skip=5, anchor=17 (k=14)
-    let outcome = run(SimulationConfig {
-        committee_size: 20,
-        duration_secs: 40,
-        replica_parameters: ReplicaParameters {
-            consensus: orcaella(1, 0, 2),
+    assert_progress(
+        &run(SimulationConfig {
+            committee_size: 20,
+            duration_secs: 40,
+            replica_parameters: ReplicaParameters {
+                consensus: orcaella(1, 0, 2),
+                ..Default::default()
+            },
             ..Default::default()
-        },
-        ..Default::default()
-    });
-    assert_eq!(outcome, Outcome::Pass);
+        }),
+        15,
+    );
 }
 
 #[test]
 fn non_optimal_mixed_n20() {
     // n=20, f=1, c=1 → commit=18, skip=7, anchor=15 (k=11)
-    let outcome = run(SimulationConfig {
-        committee_size: 20,
-        duration_secs: 40,
-        replica_parameters: ReplicaParameters {
-            consensus: orcaella(1, 1, 2),
+    assert_progress(
+        &run(SimulationConfig {
+            committee_size: 20,
+            duration_secs: 40,
+            replica_parameters: ReplicaParameters {
+                consensus: orcaella(1, 1, 2),
+                ..Default::default()
+            },
             ..Default::default()
-        },
-        ..Default::default()
-    });
-    assert_eq!(outcome, Outcome::Pass);
+        }),
+        15,
+    );
 }
 
 #[test]
 fn multi_leader_1_n9() {
-    let outcome = run(SimulationConfig {
-        committee_size: 9,
-        duration_secs: 30,
-        replica_parameters: ReplicaParameters {
-            consensus: orcaella(1, 1, 1),
+    assert_progress(
+        &run(SimulationConfig {
+            committee_size: 9,
+            duration_secs: 30,
+            replica_parameters: ReplicaParameters {
+                consensus: orcaella(1, 1, 1),
+                ..Default::default()
+            },
             ..Default::default()
-        },
-        ..Default::default()
-    });
-    assert_eq!(outcome, Outcome::Pass);
+        }),
+        10,
+    );
 }
 
 #[test]
 fn multi_leader_4_n9() {
-    let outcome = run(SimulationConfig {
-        committee_size: 9,
-        duration_secs: 30,
-        replica_parameters: ReplicaParameters {
-            consensus: orcaella(1, 1, 4),
+    assert_progress(
+        &run(SimulationConfig {
+            committee_size: 9,
+            duration_secs: 30,
+            replica_parameters: ReplicaParameters {
+                consensus: orcaella(1, 1, 4),
+                ..Default::default()
+            },
             ..Default::default()
-        },
-        ..Default::default()
-    });
-    assert_eq!(outcome, Outcome::Pass);
+        }),
+        10,
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds \`crates/simulator/tests/orcaella.rs\` with simulation tests covering 6 groups: happy-path at tight configurations, single crash fault survival, partition boundary cases, non-optimal (\`k>0\`) committee sizes, multi-leader sweep, and feasibility error validation
- Relaxes the CFT feasibility bound from \`n >= 5c+1\` to \`n >= 2c+1\` (the classical majority bound) — the stricter bound is only needed for the BFT anti-equivocation condition
- Byzantine equivocation is not injectable with the current simulator — left as a follow-up (would need simulator extension)

## Test groups

| group | scenarios | assertion |
|---|---|---|
| Happy path (k=0, full mesh) | n=3 (f=0,c=1), n=6 (f=1,c=0), n=9 (f=1,c=1) | `assert_progress` |
| OneDown within tolerance | each tight config with one node isolated | `assert_progress` |
| Partition boundary at n=9 (commit=7) | majority=7 (at threshold) and majority=6 (below) | `assert_progress` / `== NoProgress` |
| Non-optimal k>0 at n=20 | crash-only, BFT, mixed | `assert_progress` |
| Multi-leader at n=9 | leader_count ∈ {1, 4} | `assert_progress` |
| Feasibility error | BFT: n=4,f=1,c=0; CFT: n=2,f=0,c=1 | `Err(OrcaellaFaultBoundViolated)` |

## Test plan

- [x] `cargo test -p simulator --test orcaella` — all tests pass
- [x] Pre-commit hook (fmt + clippy + full test suite) passed on all commits

🤖 Generated with [Claude Code](https://claude.ai/claude-code)