### PR TITLE
fix(orchestrator): bug fixes and quick-win cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,12 +1798,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2692,7 +2686,6 @@ dependencies = [
  "dag",
  "eyre",
  "futures",
- "glob",
  "prometheus-http-query",
  "rand 0.8.5",
  "replica",

--- a/crates/cli/src/commands/remote_testbed.rs
+++ b/crates/cli/src/commands/remote_testbed.rs
@@ -395,9 +395,9 @@ async fn run_benchmark_loop<P: ProtocolCommands + ProtocolMetrics>(
         .transpose()
         .wrap_err("Failed to set up the metrics collector")?;
 
-    let mut metrics_interval = time::interval(settings.scrape_interval);
+    let mut metrics_interval = time::interval(parameters.settings.scrape_interval);
     metrics_interval.tick().await; // First tick returns immediately.
-    let mut faults_interval = time::interval(settings.faults.crash_interval());
+    let mut faults_interval = time::interval(parameters.settings.faults.crash_interval());
     faults_interval.tick().await; // First tick returns immediately.
 
     // Per-commit subdirectory so re-running the same benchmark parameters

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -12,7 +12,6 @@ aws-runtime = "1.2.3"
 aws-sdk-ec2 = "1.227.0"
 eyre = { workspace = true }
 futures = { workspace = true }
-glob = "0.3.1"
 dag.workspace = true
 replica.workspace = true
 prometheus-http-query = { version = "0.9", default-features = false, features = [
@@ -23,7 +22,7 @@ reqwest = { workspace = true }
 russh = "0.61"
 russh-sftp = "2.1"
 serde = { workspace = true }
-serde_json = "1.0.150"
+serde_json = { workspace = true }
 serde_with = "3.20.0"
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/orchestrator/src/error.rs
+++ b/crates/orchestrator/src/error.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{net::SocketAddr, string::FromUtf8Error};
+use std::{net::SocketAddr, string::FromUtf8Error, time::Duration};
 
 #[macro_export(local_inner_macros)]
 macro_rules! ensure {
@@ -84,6 +84,9 @@ pub enum SshError {
         #[source]
         source: FromUtf8Error,
     },
+
+    #[error("Timed out after {timeout:?} waiting for remote service to become healthy")]
+    WaitTimeout { timeout: Duration },
 }
 
 pub type MonitorResult<T> = Result<T, MonitorError>;

--- a/crates/orchestrator/src/logs.rs
+++ b/crates/orchestrator/src/logs.rs
@@ -4,7 +4,7 @@
 use std::cmp::max;
 
 /// Snapshot of log-analysis state — the data callers need to render or react to
-/// a benchmark's log outcome. Produced by [`LogsAnalyzer::summarise`].
+/// a benchmark's log outcome. Produced by [`LogsAnalyzer::summarize`].
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct LogsReport {
     pub node_panic: bool,
@@ -26,26 +26,6 @@ pub struct LogsAnalyzer {
     pub client_panic: bool,
 }
 
-impl PartialOrd for LogsAnalyzer {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for LogsAnalyzer {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        if self.node_panic
-            || self.client_panic
-            || self.client_errors > other.client_errors
-            || self.node_errors > other.node_errors
-        {
-            std::cmp::Ordering::Greater
-        } else {
-            std::cmp::Ordering::Less
-        }
-    }
-}
-
 impl LogsAnalyzer {
     /// Deduce the number of nodes errors from the logs.
     pub fn set_node_errors(&mut self, log: &str) {
@@ -59,9 +39,9 @@ impl LogsAnalyzer {
         self.client_panic = log.contains("panic");
     }
 
-    /// Snapshot the analyser's state into a [`LogsReport`] — the data the
+    /// Snapshot the analyzer's state into a [`LogsReport`] — the data the
     /// caller renders into a banner or reacts to programmatically.
-    pub fn summarise(&self) -> LogsReport {
+    pub fn summarize(&self) -> LogsReport {
         LogsReport {
             node_panic: self.node_panic,
             client_panic: self.client_panic,

--- a/crates/orchestrator/src/monitor.rs
+++ b/crates/orchestrator/src/monitor.rs
@@ -323,7 +323,7 @@ impl LocalGrafana {
 struct NodeExporter;
 
 impl NodeExporter {
-    const RELEASE: &'static str = "0.18.1";
+    const RELEASE: &'static str = "1.11.1";
     const DEFAULT_PORT: u16 = 9200;
     const SERVICE_PATH: &'static str = "/etc/systemd/system/node_exporter.service";
 

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -485,8 +485,8 @@ impl<P: ProtocolCommands + ProtocolMetrics> Orchestrator<P> {
 
         Ok(log_parsers
             .into_iter()
-            .max()
+            .max_by_key(|a| (a.node_panic, a.client_panic, a.node_errors, a.client_errors))
             .expect("At least one log parser")
-            .summarise())
+            .summarize())
     }
 }

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -366,7 +366,9 @@ impl<P: ProtocolCommands + ProtocolMetrics> Orchestrator<P> {
         let commands = self
             .protocol_commands
             .nodes_metrics_command(instances.clone(), parameters);
-        self.ssh_manager.wait_for_success(commands).await;
+        self.ssh_manager
+            .wait_for_success(commands, self.settings.health_check_timeout)
+            .await?;
 
         Ok(())
     }
@@ -409,7 +411,9 @@ impl<P: ProtocolCommands + ProtocolMetrics> Orchestrator<P> {
         let commands = self
             .protocol_commands
             .clients_metrics_command(clients, parameters);
-        self.ssh_manager.wait_for_success(commands).await;
+        self.ssh_manager
+            .wait_for_success(commands, self.settings.health_check_timeout)
+            .await?;
 
         Ok(())
     }

--- a/crates/orchestrator/src/provider.rs
+++ b/crates/orchestrator/src/provider.rs
@@ -119,10 +119,12 @@ pub trait ServerProviderClient: Display {
         instance: Instance,
     ) -> impl Future<Output = CloudProviderResult<()>> + Send;
 
-    /// Authorize the provided ssh public key to access machines.
+    /// Authorize the provided ssh public key to access machines. `None` means
+    /// the public key file was absent on disk; providers that require key
+    /// registration (e.g. AWS) must return an error in that case.
     fn register_ssh_public_key(
         &self,
-        public_key: String,
+        public_key: Option<String>,
     ) -> impl Future<Output = CloudProviderResult<()>> + Send;
 
     /// Return provider-specific commands to setup the instance.
@@ -222,7 +224,10 @@ pub mod test_client {
             Ok(())
         }
 
-        async fn register_ssh_public_key(&self, _public_key: String) -> CloudProviderResult<()> {
+        async fn register_ssh_public_key(
+            &self,
+            _public_key: Option<String>,
+        ) -> CloudProviderResult<()> {
             Ok(())
         }
 

--- a/crates/orchestrator/src/provider/aws.rs
+++ b/crates/orchestrator/src/provider/aws.rs
@@ -387,7 +387,7 @@ impl ServerProviderClient for AwsClient {
     async fn register_ssh_public_key(&self, public_key: Option<String>) -> CloudProviderResult<()> {
         let public_key = public_key.ok_or_else(|| {
             CloudProviderError::SshKeyNotFound(
-                self.settings.ssh_private_key_file.display().to_string(),
+                self.settings.public_key_file().display().to_string(),
             )
         })?;
         for client in self.clients.values() {

--- a/crates/orchestrator/src/provider/aws.rs
+++ b/crates/orchestrator/src/provider/aws.rs
@@ -384,7 +384,12 @@ impl ServerProviderClient for AwsClient {
         Ok(())
     }
 
-    async fn register_ssh_public_key(&self, public_key: String) -> CloudProviderResult<()> {
+    async fn register_ssh_public_key(&self, public_key: Option<String>) -> CloudProviderResult<()> {
+        let public_key = public_key.ok_or_else(|| {
+            CloudProviderError::SshKeyNotFound(
+                self.settings.ssh_private_key_file.display().to_string(),
+            )
+        })?;
         for client in self.clients.values() {
             let request = client
                 .import_key_pair()

--- a/crates/orchestrator/src/provider/custom.rs
+++ b/crates/orchestrator/src/provider/custom.rs
@@ -107,7 +107,10 @@ impl ServerProviderClient for CustomClient {
         ))
     }
 
-    async fn register_ssh_public_key(&self, _public_key: String) -> CloudProviderResult<()> {
+    async fn register_ssh_public_key(
+        &self,
+        _public_key: Option<String>,
+    ) -> CloudProviderResult<()> {
         // SSH key registration is the user's responsibility on a custom testbed.
         // This silently succeeds so that `Testbed::new` (which always calls it)
         // works for every command, not just lifecycle ones.

--- a/crates/orchestrator/src/settings.rs
+++ b/crates/orchestrator/src/settings.rs
@@ -276,21 +276,12 @@ impl Settings {
         Ok(s)
     }
 
-    /// Whether the given instance belongs to the active testbed. The region
-    /// check applies to every provider; AWS additionally requires the instance
-    /// type to match the configured specs (a single AWS account may host
-    /// machines from unrelated testbeds, so the type narrows the match).
+    /// Whether the given instance belongs to the active testbed. Filters by
+    /// region only: for AWS, `AwsClient::list_instances` already applies a
+    /// `tag:Name = testbed_id` filter at the API level so every instance in
+    /// `self.instances` already belongs to this testbed.
     pub fn filter_instance(&self, instance: &Instance) -> bool {
-        if !self.regions.contains(&instance.region) {
-            return false;
-        }
-        match &self.cloud_provider {
-            CloudProvider::Aws(c) => {
-                instance.specs.to_lowercase().replace('.', "")
-                    == c.specs.to_lowercase().replace('.', "")
-            }
-            CloudProvider::Custom(_) => true,
-        }
+        self.regions.contains(&instance.region)
     }
 
     /// Get the name of the repository (from its url).

--- a/crates/orchestrator/src/settings.rs
+++ b/crates/orchestrator/src/settings.rs
@@ -170,6 +170,11 @@ pub struct Settings {
     /// The number of times the orchestrator should retry an ssh command.
     #[serde(default = "defaults::default_ssh_retries")]
     pub ssh_retries: usize,
+    /// How long to wait for a node or client process to pass its health check
+    /// after being launched. If the deadline is exceeded, the benchmark aborts.
+    #[serde(default = "defaults::default_health_check_timeout")]
+    #[serde_as(as = "DurationSeconds")]
+    pub health_check_timeout: Duration,
 }
 
 mod defaults {
@@ -223,6 +228,10 @@ mod defaults {
 
     pub fn default_ssh_retries() -> usize {
         3
+    }
+
+    pub fn default_health_check_timeout() -> Duration {
+        Duration::from_secs(120)
     }
 }
 

--- a/crates/orchestrator/src/settings.rs
+++ b/crates/orchestrator/src/settings.rs
@@ -297,16 +297,22 @@ impl Settings {
             .to_string()
     }
 
+    /// Resolve the SSH public key path: uses `ssh_public_key_file` when set,
+    /// otherwise defaults to the private key path with a `.pub` extension.
+    pub fn public_key_file(&self) -> PathBuf {
+        self.ssh_public_key_file.clone().unwrap_or_else(|| {
+            let mut path = self.ssh_private_key_file.clone();
+            path.set_extension("pub");
+            path
+        })
+    }
+
     /// Load the ssh public key from file. Returns `None` if the file does not
     /// exist — providers that don't need a registered key (e.g. the custom
     /// provider) can accept `None` without error. Returns `Err` only for
     /// unexpected IO failures (file present but unreadable).
     pub fn load_ssh_public_key(&self) -> SettingsResult<Option<String>> {
-        let ssh_public_key_file = self.ssh_public_key_file.clone().unwrap_or_else(|| {
-            let mut private = self.ssh_private_key_file.clone();
-            private.set_extension("pub");
-            private
-        });
+        let ssh_public_key_file = self.public_key_file();
         match fs::read_to_string(&ssh_public_key_file) {
             Ok(token) => Ok(Some(token.trim_end_matches('\n').to_string())),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),

--- a/crates/orchestrator/src/settings.rs
+++ b/crates/orchestrator/src/settings.rs
@@ -297,15 +297,19 @@ impl Settings {
             .to_string()
     }
 
-    /// Load the ssh public key from file.
-    pub fn load_ssh_public_key(&self) -> SettingsResult<String> {
+    /// Load the ssh public key from file. Returns `None` if the file does not
+    /// exist — providers that don't need a registered key (e.g. the custom
+    /// provider) can accept `None` without error. Returns `Err` only for
+    /// unexpected IO failures (file present but unreadable).
+    pub fn load_ssh_public_key(&self) -> SettingsResult<Option<String>> {
         let ssh_public_key_file = self.ssh_public_key_file.clone().unwrap_or_else(|| {
             let mut private = self.ssh_private_key_file.clone();
             private.set_extension("pub");
             private
         });
         match fs::read_to_string(&ssh_public_key_file) {
-            Ok(token) => Ok(token.trim_end_matches('\n').to_string()),
+            Ok(token) => Ok(Some(token.trim_end_matches('\n').to_string())),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
             Err(e) => Err(SettingsError::SshPublicKeyFileError {
                 file: ssh_public_key_file.display().to_string(),
                 message: e.to_string(),
@@ -347,7 +351,10 @@ mod test {
     fn load_ssh_public_key() {
         let settings = Settings::new_for_test();
         let public_key = settings.load_ssh_public_key().unwrap();
-        assert_eq!(public_key, "This is a fake public key for tests");
+        assert_eq!(
+            public_key,
+            Some("This is a fake public key for tests".to_string())
+        );
     }
 
     #[test]

--- a/crates/orchestrator/src/ssh.rs
+++ b/crates/orchestrator/src/ssh.rs
@@ -16,7 +16,10 @@ use russh::{
     keys::{PrivateKeyWithHashAlg, PublicKey, load_secret_key},
 };
 use russh_sftp::client::SftpSession;
-use tokio::{task::JoinHandle, time::sleep};
+use tokio::{
+    task::JoinHandle,
+    time::{Instant, sleep},
+};
 
 use crate::{
     error::{SshError, SshResult},
@@ -245,20 +248,23 @@ impl SshConnectionManager {
         Ok(())
     }
 
-    pub async fn wait_for_success<I, S>(&self, instances: I)
+    pub async fn wait_for_success<I, S>(&self, instances: I, timeout: Duration) -> SshResult<()>
     where
         I: IntoIterator<Item = (Instance, S)> + Clone,
         S: Into<String> + Send + 'static + Clone,
     {
+        let deadline = Instant::now() + timeout;
         loop {
             sleep(Self::RETRY_DELAY).await;
-
             if self
                 .execute_per_instance(instances.clone(), CommandContext::default())
                 .await
                 .is_ok()
             {
-                break;
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(SshError::WaitTimeout { timeout });
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes seven open orchestrator issues in one PR — two correctness bugs and five quick-win cleanups — each as a separate commit to keep history readable.

- **#121** — Drop broken `Ord`/`PartialOrd` from `LogsAnalyzer` (never returned `Equal`, violated antisymmetry); replace `.max()` with `.max_by_key`.
- **#116** — Add a `health_check_timeout` setting (default 120 s) to `wait_for_success`; returns `SshError::WaitTimeout` instead of looping forever when a node never becomes healthy.
- **#103** — Use `parameters.settings` consistently in `run_benchmark_loop`; `scrape_interval` and `faults` were mistakenly read from the top-level settings clone.
- **#117** — `filter_instance` now filters by region only; `AwsClient::list_instances` already applies a `tag:Name = testbed_id` filter at the AWS API level so the redundant instance-type comparison is dropped.
- **#123** — Bump `NodeExporter` from 0.18.1 (June 2019) to 1.11.1.
- **#124** — Drop unused `glob` dependency; wire `serde_json` via `{ workspace = true }`.
- **#132** — `load_ssh_public_key` returns `Option<String>` (`None` on `NotFound`); the custom provider's no-op `register_ssh_public_key` now actually reachable without a `.pub` file on disk.

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace --all-targets` passes
- [ ] CI green
- [ ] AWS benchmark run with Orcaella (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)