### PR TITLE
refactor(orchestrator): tighten visibility — pub(crate) / private for all internals

### DIFF
--- a/crates/orchestrator/src/collector.rs
+++ b/crates/orchestrator/src/collector.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     benchmark::BenchmarkParameters,
-    error::{MonitorError, MonitorResult, TestbedResult},
+    error::{MonitorError, TestbedResult},
     protocol::ProtocolParameters,
 };
 
@@ -70,9 +70,9 @@ pub struct MetricSpec {
 /// consumer filters or groups by it (e.g. `labels["workload"] == "owned"`).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct Sample {
-    pub(crate) timestamp: f64,
-    pub(crate) value: f64,
-    pub(crate) labels: HashMap<String, String>,
+    timestamp: f64,
+    value: f64,
+    labels: HashMap<String, String>,
 }
 
 /// Accumulated benchmark output. Keyed by metric name, each entry holds every
@@ -122,7 +122,7 @@ impl<N: ProtocolParameters, C: ProtocolParameters> Collector<N, C> {
     /// Histograms fan out to one query per [`HISTOGRAM_QUANTILES`] entry; the
     /// returned samples land under `{name}.p{quantile*100}`. Everything else
     /// stores under the spec's `name`.
-    pub async fn collect(&mut self) -> MonitorResult<()> {
+    pub async fn collect(&mut self) -> Result<(), MonitorError> {
         // (storage_key, promql) pairs for this tick.
         let mut targets: Vec<(String, String)> = Vec::new();
         for spec in &self.metrics {
@@ -173,7 +173,7 @@ impl<N: ProtocolParameters, C: ProtocolParameters> Collector<N, C> {
 
     /// Write the accumulated results to `dir/measurements-{parameters:?}.json`.
     /// Preserves today's mysticeti filename convention.
-    pub fn save(&self, dir: &Path) -> MonitorResult<()> {
+    pub fn save(&self, dir: &Path) -> Result<(), MonitorError> {
         let json = serde_json::to_string_pretty(&self.results)
             .expect("BenchmarkResults always serialises");
         let mut path = PathBuf::from(dir);

--- a/crates/orchestrator/src/collector.rs
+++ b/crates/orchestrator/src/collector.rs
@@ -69,18 +69,18 @@ pub struct MetricSpec {
 /// matching time series. `labels` is the full label map for that series; the
 /// consumer filters or groups by it (e.g. `labels["workload"] == "owned"`).
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Sample {
-    pub timestamp: f64,
-    pub value: f64,
-    pub labels: HashMap<String, String>,
+pub(crate) struct Sample {
+    pub(crate) timestamp: f64,
+    pub(crate) value: f64,
+    pub(crate) labels: HashMap<String, String>,
 }
 
 /// Accumulated benchmark output. Keyed by metric name, each entry holds every
 /// sample observed across every [`Collector::collect`] tick.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BenchmarkResults<N, C> {
-    pub parameters: BenchmarkParameters<N, C>,
-    pub samples: HashMap<String, Vec<Sample>>,
+    parameters: BenchmarkParameters<N, C>,
+    samples: HashMap<String, Vec<Sample>>,
 }
 
 /// Issues PromQL queries against a deployed Prometheus instance and

--- a/crates/orchestrator/src/error.rs
+++ b/crates/orchestrator/src/error.rs
@@ -89,7 +89,7 @@ pub enum SshError {
     WaitTimeout { timeout: Duration },
 }
 
-pub type MonitorResult<T> = Result<T, MonitorError>;
+pub(crate) type MonitorResult<T> = Result<T, MonitorError>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum MonitorError {

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -12,7 +12,7 @@ pub mod collector;
 pub mod error;
 pub mod faults;
 pub mod logs;
-pub mod monitor;
+pub(crate) mod monitor;
 pub mod orchestrator;
 pub mod protocol;
 pub mod provider;

--- a/crates/orchestrator/src/logs.rs
+++ b/crates/orchestrator/src/logs.rs
@@ -15,33 +15,33 @@ pub struct LogsReport {
 
 /// A simple log analyzer counting the number of errors and panics.
 #[derive(Default, PartialEq, Eq)]
-pub struct LogsAnalyzer {
+pub(crate) struct LogsAnalyzer {
     /// The number of errors in the nodes' log files.
-    pub node_errors: usize,
+    node_errors: usize,
     /// Whether a node panicked.
-    pub node_panic: bool,
+    node_panic: bool,
     /// The number of errors in the clients' log files.
-    pub client_errors: usize,
+    client_errors: usize,
     /// Whether a client panicked.
-    pub client_panic: bool,
+    client_panic: bool,
 }
 
 impl LogsAnalyzer {
     /// Deduce the number of nodes errors from the logs.
-    pub fn set_node_errors(&mut self, log: &str) {
+    pub(crate) fn set_node_errors(&mut self, log: &str) {
         self.node_errors = log.matches(" ERROR").count();
         self.node_panic = log.contains("panic");
     }
 
     /// Deduce the number of clients errors from the logs.
-    pub fn set_client_errors(&mut self, log: &str) {
+    pub(crate) fn set_client_errors(&mut self, log: &str) {
         self.client_errors = max(self.client_errors, log.matches(" ERROR").count());
         self.client_panic = log.contains("panic");
     }
 
     /// Snapshot the analyzer's state into a [`LogsReport`] — the data the
     /// caller renders into a banner or reacts to programmatically.
-    pub fn summarize(&self) -> LogsReport {
+    pub(crate) fn summarize(&self) -> LogsReport {
         LogsReport {
             node_panic: self.node_panic,
             client_panic: self.client_panic,

--- a/crates/orchestrator/src/monitor.rs
+++ b/crates/orchestrator/src/monitor.rs
@@ -11,7 +11,7 @@ use crate::{
     ssh::{CommandContext, SshConnectionManager},
 };
 
-pub struct Monitor {
+pub(crate) struct Monitor {
     instance: Instance,
     clients: Vec<Instance>,
     nodes: Vec<Instance>,
@@ -20,7 +20,7 @@ pub struct Monitor {
 
 impl Monitor {
     /// Create a new monitor.
-    pub fn new(
+    pub(crate) fn new(
         instance: Instance,
         clients: Vec<Instance>,
         nodes: Vec<Instance>,
@@ -35,7 +35,7 @@ impl Monitor {
     }
 
     /// Dependencies to install.
-    pub fn dependencies() -> Vec<String> {
+    pub(crate) fn dependencies() -> Vec<String> {
         let mut commands: Vec<String> = Vec::new();
         commands.extend(Prometheus::install_commands().into_iter().map(String::from));
         commands.extend(Grafana::install_commands().into_iter().map(String::from));
@@ -44,7 +44,7 @@ impl Monitor {
     }
 
     /// Start a prometheus instance on the dedicated motoring machine.
-    pub async fn start_prometheus<P: ProtocolMetrics>(
+    pub(crate) async fn start_prometheus<P: ProtocolMetrics>(
         &self,
         protocol_commands: &P,
         parameters: &Parameters<P>,
@@ -65,7 +65,7 @@ impl Monitor {
     }
 
     /// Start grafana on the dedicated motoring machine.
-    pub async fn start_grafana(&self) -> MonitorResult<()> {
+    pub(crate) async fn start_grafana(&self) -> MonitorResult<()> {
         // Configure and reload grafana.
         let instance = std::iter::once(self.instance.clone());
         let commands = Grafana::setup_commands();
@@ -77,13 +77,13 @@ impl Monitor {
     }
 
     /// The public address of the grafana instance.
-    pub fn grafana_address(&self) -> String {
+    pub(crate) fn grafana_address(&self) -> String {
         format!("http://{}:{}", self.instance.main_ip, Grafana::DEFAULT_PORT)
     }
 
     /// The public address of the prometheus instance, used by the consumer to
     /// query metrics over PromQL.
-    pub fn prometheus_address(&self) -> String {
+    pub(crate) fn prometheus_address(&self) -> String {
         format!(
             "http://{}:{}",
             self.instance.main_ip,
@@ -93,16 +93,16 @@ impl Monitor {
 }
 
 /// Generate the commands to setup prometheus on the given instances.
-pub struct Prometheus;
+pub(crate) struct Prometheus;
 
 impl Prometheus {
     /// The default prometheus configuration path.
     const DEFAULT_PROMETHEUS_CONFIG_PATH: &'static str = "/etc/prometheus/prometheus.yml";
     /// The default prometheus port.
-    pub const DEFAULT_PORT: u16 = 9090;
+    pub(crate) const DEFAULT_PORT: u16 = 9090;
 
     /// The commands to install prometheus.
-    pub fn install_commands() -> Vec<&'static str> {
+    pub(crate) fn install_commands() -> Vec<&'static str> {
         vec![
             "sudo apt-get -y install prometheus",
             "sudo chmod 777 -R /var/lib/prometheus/ /etc/prometheus/",
@@ -110,7 +110,7 @@ impl Prometheus {
     }
 
     /// Generate the commands to update the prometheus configuration and restart prometheus.
-    pub fn setup_commands<I, P>(
+    pub(crate) fn setup_commands<I, P>(
         nodes: I,
         _clients: I,
         protocol: &P,
@@ -182,16 +182,16 @@ impl Prometheus {
     }
 }
 
-pub struct Grafana;
+pub(crate) struct Grafana;
 
 impl Grafana {
     /// The path to the datasources directory.
     const DATASOURCES_PATH: &'static str = "/etc/grafana/provisioning/datasources";
     /// The default grafana port.
-    pub const DEFAULT_PORT: u16 = 3000;
+    pub(crate) const DEFAULT_PORT: u16 = 3000;
 
     /// The commands to install grafana.
-    pub fn install_commands() -> Vec<&'static str> {
+    pub(crate) fn install_commands() -> Vec<&'static str> {
         vec![
             "sudo apt-get install -y apt-transport-https software-properties-common wget",
             "sudo wget -q -O /etc/apt/keyrings/grafana.key https://apt.grafana.com/gpg.key",
@@ -207,7 +207,7 @@ impl Grafana {
     }
 
     /// Generate the commands to update the grafana datasource and restart grafana.
-    pub fn setup_commands() -> String {
+    pub(crate) fn setup_commands() -> String {
         [
             &format!("(rm -r {} || true)", Self::DATASOURCES_PATH),
             &format!("mkdir -p {}", Self::DATASOURCES_PATH),
@@ -249,7 +249,7 @@ impl NodeExporter {
     const DEFAULT_PORT: u16 = 9200;
     const SERVICE_PATH: &'static str = "/etc/systemd/system/node_exporter.service";
 
-    pub fn install_commands() -> Vec<String> {
+    pub(crate) fn install_commands() -> Vec<String> {
         let build = format!("node_exporter-{}.linux-amd64", Self::RELEASE);
         let source = format!(
             "https://github.com/prometheus/node_exporter/releases/download/v{}/{build}.tar.gz",

--- a/crates/orchestrator/src/orchestrator/run.rs
+++ b/crates/orchestrator/src/orchestrator/run.rs
@@ -167,7 +167,10 @@ impl<P: ProtocolCommands + ProtocolMetrics> Orchestrator<P> {
         Ok(client_parsers
             .into_iter()
             .chain(node_parsers)
-            .max_by_key(|a| (a.node_panic, a.client_panic, a.node_errors, a.client_errors))
+            .max_by_key(|a| {
+                let s = a.summarize();
+                (s.node_panic, s.client_panic, s.node_errors, s.client_errors)
+            })
             .expect("At least one log parser")
             .summarize())
     }

--- a/crates/orchestrator/src/provider.rs
+++ b/crates/orchestrator/src/provider.rs
@@ -34,17 +34,17 @@ impl From<&str> for InstanceStatus {
 #[derive(Debug, Deserialize, Clone, Eq, PartialEq, Hash)]
 pub struct Instance {
     /// The unique identifier of the instance.
-    pub id: String,
+    pub(crate) id: String,
     /// The region where the instance runs.
     pub region: String,
     /// The public ip address of the instance (accessible from anywhere).
     pub main_ip: Ipv4Addr,
     /// The list of tags associated with the instance.
-    pub tags: Vec<String>,
+    pub(crate) tags: Vec<String>,
     /// The specs of the instance.
-    pub specs: String,
+    pub(crate) specs: String,
     /// The current status of the instance.
-    pub status: InstanceStatus,
+    pub(crate) status: InstanceStatus,
 }
 
 impl Instance {
@@ -64,7 +64,7 @@ impl Instance {
     }
 
     /// Return the ssh address to connect to the instance.
-    pub fn ssh_address(&self) -> SocketAddr {
+    pub(crate) fn ssh_address(&self) -> SocketAddr {
         SocketAddr::new(self.main_ip.into(), 22)
     }
 

--- a/crates/orchestrator/src/settings.rs
+++ b/crates/orchestrator/src/settings.rs
@@ -59,16 +59,16 @@ impl Repository {
 #[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq, Debug)]
 pub struct AwsConfig {
     /// The EC2 instance type, e.g. `m5d.8xlarge`.
-    pub specs: String,
+    pub(crate) specs: String,
     /// The path to the AWS credentials file.
     #[serde(skip_serializing)]
-    pub token_file: PathBuf,
+    pub(crate) token_file: PathBuf,
 }
 
 /// A single pre-provisioned machine for the custom provider, tagged with the
 /// region it belongs to (which must appear in [`Settings::regions`]).
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
-pub struct CustomInstance {
+pub(crate) struct CustomInstance {
     pub region: String,
     pub ip: Ipv4Addr,
 }
@@ -78,9 +78,9 @@ pub struct CustomInstance {
 #[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq, Debug)]
 pub struct CustomConfig {
     /// The SSH username configured on the pre-provisioned machines.
-    pub ssh_username: String,
+    pub(crate) ssh_username: String,
     /// The pre-provisioned machines.
-    pub instances: Vec<CustomInstance>,
+    pub(crate) instances: Vec<CustomInstance>,
 }
 
 /// The list of supported cloud providers.
@@ -280,12 +280,12 @@ impl Settings {
     /// region only: for AWS, `AwsClient::list_instances` already applies a
     /// `tag:Name = testbed_id` filter at the API level so every instance in
     /// `self.instances` already belongs to this testbed.
-    pub fn filter_instance(&self, instance: &Instance) -> bool {
+    pub(crate) fn filter_instance(&self, instance: &Instance) -> bool {
         self.regions.contains(&instance.region)
     }
 
     /// Get the name of the repository (from its url).
-    pub fn repository_name(&self) -> String {
+    pub(crate) fn repository_name(&self) -> String {
         self.repository
             .url
             .path_segments()
@@ -299,7 +299,7 @@ impl Settings {
 
     /// Resolve the SSH public key path: uses `ssh_public_key_file` when set,
     /// otherwise defaults to the private key path with a `.pub` extension.
-    pub fn public_key_file(&self) -> PathBuf {
+    pub(crate) fn public_key_file(&self) -> PathBuf {
         self.ssh_public_key_file.clone().unwrap_or_else(|| {
             let mut path = self.ssh_private_key_file.clone();
             path.set_extension("pub");
@@ -311,7 +311,7 @@ impl Settings {
     /// exist — providers that don't need a registered key (e.g. the custom
     /// provider) can accept `None` without error. Returns `Err` only for
     /// unexpected IO failures (file present but unreadable).
-    pub fn load_ssh_public_key(&self) -> SettingsResult<Option<String>> {
+    pub(crate) fn load_ssh_public_key(&self) -> SettingsResult<Option<String>> {
         let ssh_public_key_file = self.public_key_file();
         match fs::read_to_string(&ssh_public_key_file) {
             Ok(token) => Ok(Some(token.trim_end_matches('\n').to_string())),

--- a/crates/orchestrator/src/ssh.rs
+++ b/crates/orchestrator/src/ssh.rs
@@ -4,8 +4,8 @@
 mod command;
 mod connection;
 
-pub use command::{CommandContext, CommandStatus};
-pub use connection::SshConnection;
+pub(crate) use command::{CommandContext, CommandStatus};
+pub(crate) use connection::SshConnection;
 
 use std::{path::PathBuf, time::Duration};
 
@@ -59,7 +59,7 @@ impl SshConnectionManager {
     }
 
     /// Create a new ssh connection with the provided host.
-    pub async fn connect(&self, address: std::net::SocketAddr) -> SshResult<SshConnection> {
+    pub(crate) async fn connect(&self, address: std::net::SocketAddr) -> SshResult<SshConnection> {
         let mut error = None;
         for _ in 0..self.retries + 1 {
             match SshConnection::new(
@@ -79,7 +79,7 @@ impl SshConnectionManager {
     }
 
     /// Execute the specified ssh command on all provided instances.
-    pub async fn execute<I, S>(
+    pub(crate) async fn execute<I, S>(
         &self,
         instances: I,
         command: S,
@@ -96,7 +96,7 @@ impl SshConnectionManager {
     }
 
     /// Execute the ssh command associated with each instance.
-    pub async fn execute_per_instance<I, S>(
+    pub(crate) async fn execute_per_instance<I, S>(
         &self,
         instances: I,
         context: CommandContext,
@@ -114,7 +114,7 @@ impl SshConnectionManager {
             .collect::<SshResult<_>>()
     }
 
-    pub fn run_per_instance<I, S>(
+    pub(crate) fn run_per_instance<I, S>(
         &self,
         instances: I,
         context: CommandContext,
@@ -138,7 +138,7 @@ impl SshConnectionManager {
     }
 
     /// Wait until a command running in the background returns or started.
-    pub async fn wait_for_command<I>(
+    pub(crate) async fn wait_for_command<I>(
         &self,
         instances: I,
         command_id: &str,
@@ -167,7 +167,11 @@ impl SshConnectionManager {
         Ok(())
     }
 
-    pub async fn wait_for_success<I, S>(&self, instances: I, timeout: Duration) -> SshResult<()>
+    pub(crate) async fn wait_for_success<I, S>(
+        &self,
+        instances: I,
+        timeout: Duration,
+    ) -> SshResult<()>
     where
         I: IntoIterator<Item = (Instance, S)> + Clone,
         S: Into<String> + Send + 'static + Clone,
@@ -189,7 +193,7 @@ impl SshConnectionManager {
     }
 
     /// Kill a command running in the background of the specified instances.
-    pub async fn kill<I>(&self, instances: I, command_id: &str) -> SshResult<()>
+    pub(crate) async fn kill<I>(&self, instances: I, command_id: &str) -> SshResult<()>
     where
         I: IntoIterator<Item = Instance>,
     {

--- a/crates/orchestrator/src/ssh/command.rs
+++ b/crates/orchestrator/src/ssh/command.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 /// The status of a ssh command running in the background.
 #[derive(PartialEq, Eq)]
-pub enum CommandStatus {
+pub(crate) enum CommandStatus {
     Running,
     Terminated,
 }
@@ -13,7 +13,7 @@ pub enum CommandStatus {
 impl CommandStatus {
     /// Return whether a background command is still running. Returns `Terminated` if the
     /// command is not running in the background.
-    pub fn status(command_id: &str, text: &str) -> Self {
+    pub(crate) fn status(command_id: &str, text: &str) -> Self {
         if text.contains(command_id) {
             Self::Running
         } else {
@@ -24,19 +24,19 @@ impl CommandStatus {
 
 /// The command to execute on all specified remote machines.
 #[derive(Clone, Default)]
-pub struct CommandContext {
+pub(crate) struct CommandContext {
     /// Whether to run the command in the background (and return immediately). Commands
     /// running in the background are identified by a unique id.
-    pub background: Option<String>,
+    background: Option<String>,
     /// The path from where to execute the command.
-    pub path: Option<PathBuf>,
+    path: Option<PathBuf>,
     /// The log file to redirect all stdout and stderr.
-    pub log_file: Option<PathBuf>,
+    log_file: Option<PathBuf>,
 }
 
 impl CommandContext {
     /// Create a new ssh command.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             background: None,
             path: None,
@@ -45,25 +45,25 @@ impl CommandContext {
     }
 
     /// Set id of the command and indicate that it should run in the background.
-    pub fn run_background(mut self, id: String) -> Self {
+    pub(crate) fn run_background(mut self, id: String) -> Self {
         self.background = Some(id);
         self
     }
 
     /// Set the path from where to execute the command.
-    pub fn with_execute_from_path(mut self, path: PathBuf) -> Self {
+    pub(crate) fn with_execute_from_path(mut self, path: PathBuf) -> Self {
         self.path = Some(path);
         self
     }
 
     /// Set the log file where to redirect stdout and stderr.
-    pub fn with_log_file(mut self, path: PathBuf) -> Self {
+    pub(crate) fn with_log_file(mut self, path: PathBuf) -> Self {
         self.log_file = Some(path);
         self
     }
 
     /// Apply the context to a base command.
-    pub fn apply<S: Into<String>>(&self, base_command: S) -> String {
+    pub(crate) fn apply<S: Into<String>>(&self, base_command: S) -> String {
         let mut str = base_command.into();
         if let Some(log_file) = &self.log_file {
             str = format!("{str} |& tee {}", log_file.as_path().display());

--- a/crates/orchestrator/src/ssh/connection.rs
+++ b/crates/orchestrator/src/ssh/connection.rs
@@ -50,7 +50,7 @@ impl client::Handler for AcceptAllHostKeys {
 }
 
 /// Representation of an ssh connection.
-pub struct SshConnection {
+pub(crate) struct SshConnection {
     /// The russh client handle for this session.
     handle: Handle<AcceptAllHostKeys>,
     /// The host address.
@@ -64,7 +64,7 @@ impl SshConnection {
     const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
     /// Create a new ssh connection with a specific host.
-    pub async fn new<P: AsRef<Path>>(
+    pub(crate) async fn new<P: AsRef<Path>>(
         address: SocketAddr,
         username: &str,
         private_key_file: P,
@@ -107,7 +107,7 @@ impl SshConnection {
     }
 
     /// Set the maximum number of times to retries to establish a connection and execute commands.
-    pub fn with_retries(mut self, retries: usize) -> Self {
+    pub(crate) fn with_retries(mut self, retries: usize) -> Self {
         self.retries = retries;
         self
     }
@@ -137,7 +137,7 @@ impl SshConnection {
     }
 
     /// Execute an ssh command on the remote machine.
-    pub async fn execute(&self, command: String) -> SshResult<(String, String)> {
+    pub(crate) async fn execute(&self, command: String) -> SshResult<(String, String)> {
         let mut error = None;
         for _ in 0..self.retries + 1 {
             let mut channel = match self.handle.channel_open_session().await {
@@ -223,7 +223,7 @@ impl SshConnection {
     }
 
     /// Download a file from the remote machine over SFTP.
-    pub async fn download<P: AsRef<Path>>(&self, path: P) -> SshResult<String> {
+    pub(crate) async fn download<P: AsRef<Path>>(&self, path: P) -> SshResult<String> {
         let path = path.as_ref();
         let mut error = None;
         for _ in 0..self.retries + 1 {


### PR DESCRIPTION
## Summary

Follows the visibility audit done during PR #168 review. ~40 items were `pub` but never referenced outside the crate. This PR restricts them to `pub(crate)` or private — one commit per logical cluster.

| Commit | What changed |
|--------|-------------|
| ssh | `SshConnection`, `CommandContext`, `CommandStatus`, all `SshConnectionManager` methods except `new`/`with_timeout`/`with_retries` → `pub(crate)`; `CommandContext` fields → private |
| monitor | Entire module (`Monitor`, `Prometheus`, `Grafana`) → `pub(crate)`; `lib.rs` module decl → `pub(crate) mod` |
| logs | `LogsAnalyzer` → `pub(crate)`; its four fields → private; methods → `pub(crate)` |
| provider | `Instance` fields `id`/`tags`/`specs`/`status` and `ssh_address` → `pub(crate)`; `region`/`main_ip`/`is_*` stay `pub` |
| settings | `filter_instance`, `repository_name`, `public_key_file`, `load_ssh_public_key`, `AwsConfig` fields, `CustomInstance`, `CustomConfig` fields → `pub(crate)` |
| error/collector | `MonitorResult` → `pub(crate)`; `Sample` → `pub(crate)` with private fields; `BenchmarkResults` fields → private |

## Test plan

- [ ] `cargo check --workspace` passes (verified locally after each commit)
- [ ] `cargo test --workspace` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)