### PR TITLE
refactor(orchestrator): introduce BenchmarkSession and tick() (issue #172)

### DIFF
--- a/crates/cli/src/remote/benchmark.rs
+++ b/crates/cli/src/remote/benchmark.rs
@@ -1,20 +1,17 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
-
 use eyre::{Context, Result};
 use orchestrator::{
     benchmark::{BenchmarkParameters, Parameters},
-    collector::Collector,
     error::MonitorError,
-    faults::CrashRecoverySchedule,
     orchestrator::{MonitoringReport, Orchestrator},
     protocol::{ProtocolCommands, ProtocolMetrics, ProtocolParameters as _},
     provider::Instance,
+    report::TickReport,
+    session::BenchmarkSession,
     settings::Settings,
 };
-use tokio::time::{self, Instant};
 
 use crate::{
     remote::protocol::{ClientParameters, NodeParameters, ReplicaProtocol},
@@ -244,6 +241,7 @@ impl RemoteBenchmarkDriver {
     /// Drive the metrics + faults tick loop for a single benchmark run. Owns the
     /// `tokio::select!`, the fault schedule, and (when monitoring is deployed) a
     /// PromQL [`Collector`] that polls Prometheus on the metrics tick.
+    /// Drive the metrics + faults tick loop for a single benchmark run.
     async fn run_benchmark_loop<P: ProtocolCommands + ProtocolMetrics>(
         &mut self,
         orchestrator: &Orchestrator<P>,
@@ -263,77 +261,46 @@ impl RemoteBenchmarkDriver {
             )
         };
 
-        let (_, nodes, _) = orchestrator
-            .select_instances(parameters)
-            .wrap_err("Failed to select instances for benchmark loop")?;
-        let mut schedule = CrashRecoverySchedule::new(parameters.settings.faults.clone(), nodes);
-
-        let mut collector = monitoring
-            .map(|report| {
-                Collector::new(
-                    &report.prometheus_address,
-                    parameters.clone(),
-                    orchestrator.protocol().metrics(),
-                )
-            })
-            .transpose()
-            .wrap_err("Failed to set up the metrics collector")?;
-
-        let mut metrics_interval = time::interval(parameters.settings.scrape_interval);
-        metrics_interval.tick().await;
-        let mut faults_interval = time::interval(parameters.settings.faults.crash_interval());
-        faults_interval.tick().await;
+        let mut session = BenchmarkSession::new(orchestrator, parameters, monitoring)
+            .await
+            .wrap_err("Failed to start benchmark session")?;
 
         let results_path = self
             .settings
             .results_dir
             .join(format!("results-{}", self.settings.repository.commit));
-        std::fs::create_dir_all(&results_path)
+        tokio::fs::create_dir_all(&results_path)
+            .await
             .map_err(MonitorError::ResultsWriteError)
             .wrap_err("Failed to create results directory")?;
 
         self.progress.start(Some(benchmark_duration), &label);
-        let start = Instant::now();
         let outcome = loop {
-            tokio::select! {
-                _ = metrics_interval.tick() => {
-                    let elapsed = start.elapsed();
+            match session.tick(orchestrator, parameters).await {
+                Err(e) => break Err(e).wrap_err("Benchmark tick failed"),
+                Ok(TickReport::MetricsTick { elapsed, results }) => {
                     self.progress.set_elapsed(elapsed);
-                    if let Some(collector) = collector.as_mut() {
-                        if let Err(error) = collector.collect().await {
-                            break Err(error);
-                        }
-                        if let Err(error) = collector.save(&results_path) {
-                            break Err(error);
+                    if let Some(yaml) = results {
+                        let path = results_path.join(format!("measurements-{:?}.yaml", parameters));
+                        if let Err(e) = tokio::fs::write(&path, &yaml).await {
+                            break Err(MonitorError::ResultsWriteError(e))
+                                .wrap_err("Failed to save benchmark results");
                         }
                     }
                     if elapsed > benchmark_duration {
                         break Ok(());
                     }
-                },
-                _ = faults_interval.tick() => {
-                    let action = match orchestrator
-                        .apply_faults_step(parameters, &mut schedule)
-                        .await
-                    {
-                        Ok(action) => action,
-                        Err(error) => {
-                            self.progress.stop();
-                            return Err(error).wrap_err("Failed to apply fault schedule");
-                        }
-                    };
+                }
+                Ok(TickReport::FaultUpdate { elapsed, action }) => {
+                    self.progress.set_elapsed(elapsed);
                     if !action.kill.is_empty() || !action.boot.is_empty() {
-                        self.progress.suspend(|| eprintln!("Testbed update: {action}"));
+                        self.progress
+                            .suspend(|| eprintln!("Testbed update: {action}"));
                     }
                 }
             }
-            self.progress.set_elapsed(
-                start
-                    .elapsed()
-                    .min(benchmark_duration + Duration::from_secs(1)),
-            );
         };
         self.progress.stop();
-        outcome.wrap_err("Metrics collection failed")
+        outcome
     }
 }

--- a/crates/orchestrator/src/collector.rs
+++ b/crates/orchestrator/src/collector.rs
@@ -101,6 +101,11 @@ pub struct Collector<N, C> {
 }
 
 impl<N: ProtocolParameters, C: ProtocolParameters> Collector<N, C> {
+    /// Return a reference to the accumulated results.
+    pub fn results(&self) -> &BenchmarkResults<N, C> {
+        &self.results
+    }
+
     /// `prometheus_address` is the URL the consumer received in
     /// [`crate::orchestrator::MonitoringReport::prometheus_address`].
     pub fn new(

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -17,6 +17,7 @@ pub mod orchestrator;
 pub mod protocol;
 pub mod provider;
 pub mod report;
+pub mod session;
 pub mod settings;
 pub mod ssh;
 pub mod testbed;

--- a/crates/orchestrator/src/session.rs
+++ b/crates/orchestrator/src/session.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-benchmark-run state. A [`BenchmarkSession`] is created once per run via
+//! [`BenchmarkSession::new`] and advanced one tick at a time via
+//! [`BenchmarkSession::tick`].
+
+use tokio::time::{self, Instant, Interval};
+
+use crate::{
+    benchmark::Parameters,
+    collector::Collector,
+    error::TestbedResult,
+    faults::CrashRecoverySchedule,
+    orchestrator::Orchestrator,
+    protocol::{Protocol, ProtocolCommands, ProtocolMetrics},
+    report::{MonitoringReport, TickReport},
+};
+
+/// Mutable state for a single benchmark run.
+///
+/// A session is single-use: create one per run with [`BenchmarkSession::new`],
+/// drive it to completion with [`BenchmarkSession::tick`], then drop it.
+pub struct BenchmarkSession<P: Protocol> {
+    pub(crate) schedule: CrashRecoverySchedule,
+    pub(crate) collector: Option<Collector<P::NodeParameters, P::ClientParameters>>,
+    metrics_interval: Interval,
+    faults_interval: Interval,
+    /// Instant the session started; used to compute elapsed time on each tick.
+    pub start: Instant,
+}
+
+impl<P: ProtocolCommands + ProtocolMetrics> BenchmarkSession<P> {
+    /// Initialise a benchmark session. Consumes the first (immediately-firing)
+    /// tick of each interval so the first call to [`Self::tick`] waits a full
+    /// interval before returning.
+    pub async fn new(
+        orchestrator: &Orchestrator<P>,
+        parameters: &Parameters<P>,
+        monitoring: Option<&MonitoringReport>,
+    ) -> TestbedResult<Self> {
+        let (_, nodes, _) = orchestrator.select_instances(parameters)?;
+        let schedule = CrashRecoverySchedule::new(parameters.settings.faults.clone(), nodes);
+        let collector = monitoring
+            .map(|r| {
+                Collector::new(
+                    &r.prometheus_address,
+                    parameters.clone(),
+                    orchestrator.protocol().metrics(),
+                )
+            })
+            .transpose()?;
+
+        let mut metrics_interval = time::interval(parameters.settings.scrape_interval);
+        metrics_interval.tick().await;
+        let mut faults_interval = time::interval(parameters.settings.faults.crash_interval());
+        faults_interval.tick().await;
+
+        Ok(Self {
+            schedule,
+            collector,
+            metrics_interval,
+            faults_interval,
+            start: Instant::now(),
+        })
+    }
+
+    /// Advance the session by one tick. Blocks until either the metrics
+    /// interval or the faults interval fires, then returns a [`TickReport`].
+    pub async fn tick(
+        &mut self,
+        orchestrator: &Orchestrator<P>,
+        parameters: &Parameters<P>,
+    ) -> TestbedResult<TickReport> {
+        tokio::select! {
+            _ = self.metrics_interval.tick() => {
+                if let Some(collector) = self.collector.as_mut() {
+                    collector.collect().await?;
+                }
+                let results = self.collector.as_ref().map(|c| c.results().to_yaml());
+                Ok(TickReport::MetricsTick {
+                    elapsed: self.start.elapsed(),
+                    results,
+                })
+            }
+            _ = self.faults_interval.tick() => {
+                let action = orchestrator
+                    .apply_faults_step(parameters, &mut self.schedule)
+                    .await?;
+                Ok(TickReport::FaultUpdate {
+                    elapsed: self.start.elapsed(),
+                    action,
+                })
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes most of issue #172. Moves all per-benchmark-run state out of the CLI into a new `BenchmarkSession` type in the orchestrator crate.

**New: `orchestrator/src/session.rs`**
- `BenchmarkSession<P>` owns `CrashRecoverySchedule`, `Option<Collector>`, both `tokio::time::Interval`s, and the `start: Instant`
- `BenchmarkSession::new(orchestrator, parameters, monitoring)` — initialises state, consumes the first immediate tick of each interval
- `BenchmarkSession::tick(orchestrator, parameters)` — one iteration of `tokio::select!` returning `TickReport::MetricsTick` or `TickReport::FaultUpdate`
- `tick()` calls the existing public `Orchestrator::apply_faults_step()` — no new public API added to `Orchestrator`

**Updated: `collector.rs`**
- Add `Collector::results()` accessor so `tick()` can call `results.to_yaml()`

**Updated: `cli/src/remote/benchmark.rs`**
- `run_benchmark_loop` shrinks from ~90 lines to ~40: create session, `loop { match session.tick() }`, stop progress
- File writes use `tokio::fs` consistently
- Unused imports (`Collector`, `CrashRecoverySchedule`, `tokio::time`) removed

## Test plan

- [ ] `cargo check --workspace`
- [ ] `cargo clippy --workspace --all-targets`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)