### PR TITLE
refactor(cli): centralise benchmark result export in Exporter

### DIFF
--- a/crates/cli/src/exporter.rs
+++ b/crates/cli/src/exporter.rs
@@ -67,6 +67,7 @@ struct DagRecord<'a> {
     commit: &'a CommitData,
 }
 
+#[derive(Clone)]
 pub struct Exporter {
     output_dir: PathBuf,
 }
@@ -195,6 +196,15 @@ impl Exporter {
                 }
             }
             Ok(())
+        })
+    }
+
+    /// Write benchmark result YAML to `measurements-{key}.yaml` using the same
+    /// atomic write-rename pattern as other artefacts. `key` is typically
+    /// `format!("{parameters:?}")` at the call site.
+    pub fn write_benchmark_result(&self, yaml: &str, key: &str) -> Result<()> {
+        Self::write_atomic(&self.output_dir, &format!("measurements-{key}.yaml"), |w| {
+            w.write_all(yaml.as_bytes())
         })
     }
 

--- a/crates/cli/src/remote/benchmark.rs
+++ b/crates/cli/src/remote/benchmark.rs
@@ -4,7 +4,6 @@
 use eyre::{Context, Result};
 use orchestrator::{
     benchmark::{BenchmarkParameters, Parameters},
-    error::MonitorError,
     orchestrator::{MonitoringReport, Orchestrator},
     protocol::{ProtocolCommands, ProtocolMetrics, ProtocolParameters as _},
     provider::Instance,
@@ -14,6 +13,7 @@ use orchestrator::{
 };
 
 use crate::{
+    exporter::Exporter,
     remote::protocol::{ClientParameters, NodeParameters, ReplicaProtocol},
     terminal::{BannerPrinter, Progress},
 };
@@ -269,10 +269,8 @@ impl RemoteBenchmarkDriver {
             .settings
             .results_dir
             .join(format!("results-{}", self.settings.repository.commit));
-        tokio::fs::create_dir_all(&results_path)
-            .await
-            .map_err(MonitorError::ResultsWriteError)
-            .wrap_err("Failed to create results directory")?;
+        let exporter =
+            Exporter::new(results_path).wrap_err("Failed to create results directory")?;
 
         self.progress.start(Some(benchmark_duration), &label);
         let outcome = loop {
@@ -281,10 +279,15 @@ impl RemoteBenchmarkDriver {
                 Ok(TickReport::MetricsTick { elapsed, results }) => {
                     self.progress.set_elapsed(elapsed);
                     if let Some(yaml) = results {
-                        let path = results_path.join(format!("measurements-{:?}.yaml", parameters));
-                        if let Err(e) = tokio::fs::write(&path, &yaml).await {
-                            break Err(MonitorError::ResultsWriteError(e))
-                                .wrap_err("Failed to save benchmark results");
+                        let key = format!("{parameters:?}");
+                        let exp = exporter.clone();
+                        if let Err(e) = tokio::task::spawn_blocking(move || {
+                            exp.write_benchmark_result(&yaml, &key)
+                        })
+                        .await
+                        .unwrap()
+                        {
+                            break Err(e).wrap_err("Failed to save benchmark results");
                         }
                     }
                     if elapsed > benchmark_duration {

--- a/crates/cli/src/remote/benchmark.rs
+++ b/crates/cli/src/remote/benchmark.rs
@@ -280,12 +280,12 @@ impl RemoteBenchmarkDriver {
                     self.progress.set_elapsed(elapsed);
                     if let Some(yaml) = results {
                         let key = format!("{parameters:?}");
-                        let exp = exporter.clone();
+                        let e = exporter.clone();
                         if let Err(e) = tokio::task::spawn_blocking(move || {
-                            exp.write_benchmark_result(&yaml, &key)
+                            e.write_benchmark_result(&yaml, &key)
                         })
                         .await
-                        .unwrap()
+                        .expect("failed to write benchmark results to file")
                         {
                             break Err(e).wrap_err("Failed to save benchmark results");
                         }

--- a/crates/cli/src/remote/benchmark.rs
+++ b/crates/cli/src/remote/benchmark.rs
@@ -280,9 +280,9 @@ impl RemoteBenchmarkDriver {
                     self.progress.set_elapsed(elapsed);
                     if let Some(yaml) = results {
                         let key = format!("{parameters:?}");
-                        let e = exporter.clone();
+                        let exporter_clone = exporter.clone();
                         let result = tokio::task::spawn_blocking(move || {
-                            e.write_benchmark_result(&yaml, &key)
+                            exporter_clone.write_benchmark_result(&yaml, &key)
                         })
                         .await
                         .map_err(|e| eyre::eyre!("write_benchmark_result task panicked: {e}"))

--- a/crates/cli/src/remote/benchmark.rs
+++ b/crates/cli/src/remote/benchmark.rs
@@ -281,12 +281,13 @@ impl RemoteBenchmarkDriver {
                     if let Some(yaml) = results {
                         let key = format!("{parameters:?}");
                         let e = exporter.clone();
-                        if let Err(e) = tokio::task::spawn_blocking(move || {
+                        let result = tokio::task::spawn_blocking(move || {
                             e.write_benchmark_result(&yaml, &key)
                         })
                         .await
-                        .expect("failed to write benchmark results to file")
-                        {
+                        .map_err(|e| eyre::eyre!("write_benchmark_result task panicked: {e}"))
+                        .and_then(|r| r);
+                        if let Err(e) = result {
                             break Err(e).wrap_err("Failed to save benchmark results");
                         }
                     }


### PR DESCRIPTION
## Summary

`run_benchmark_loop` in `benchmark.rs` owned its own file-export logic (results path, `tokio::fs::create_dir_all`, `tokio::fs::write`) inconsistent with `cli/src/exporter.rs`, which is the CLI's single source of truth for file layout and crash-safe atomic writes (`write_atomic` via `NamedTempFile` + rename).

Part of #172.

**`exporter.rs`**
- `#[derive(Clone)]` on `Exporter` (it wraps a `PathBuf`)
- New `write_benchmark_result(&self, yaml, key)` using the existing `write_atomic` helper — consistent naming with `write_run_result`

**`benchmark.rs`**
- Replace inline dir creation + file write with `Exporter::new(results_path)?`
- Use `tokio::task::spawn_blocking` so the async runtime is never blocked by file IO
- Flatten the `JoinHandle` result via `map_err + and_then` so a panic in the blocking task surfaces as `break Err(...)` rather than crashing the process

## Test plan

- [ ] `cargo check --workspace`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)