### PR TITLE
ci: raise tarpaulin per-test timeout to 180s

### DIFF
--- a/.github/workflows/code.yaml
+++ b/.github/workflows/code.yaml
@@ -77,6 +77,7 @@ jobs:
           cargo tarpaulin \
             --workspace \
             --skip-clean \
+            --timeout 180 \
             --run-types Bins --run-types Lib --run-types Tests \
             --out Html --out Xml \
             --exclude-files "crates/**/benches/**/*" \


### PR DESCRIPTION
## Problem

The `Test coverage` job (`cargo tarpaulin`, runs only on `main`) is failing — not on compile or lint, but on a **per-test timeout**.

Tarpaulin wraps every test in ptrace/breakpoint instrumentation, slowing wall-clock execution several-fold. The 20-node Orcaella simulator tests in `crates/simulator/tests/orcaella.rs` (`non_optimal_bft_n20`, `non_optimal_crash_only_n20`, `non_optimal_mixed_n20`) exceed tarpaulin's **default 60s per-test timeout**, aborting the whole coverage run:

```
test non_optimal_bft_n20 has been running for over 60 seconds
...
ERROR cargo_tarpaulin: Failed to run tests: Error: Timed out waiting for test response
```

These tests pass quickly under the regular `cargo nextest` job (which is green) — only the instrumented coverage run is affected.

## Fix

Add `--timeout 180` to the tarpaulin invocation. This keeps all three tests live and counted toward coverage rather than hiding them (`#[ignore]`) or shrinking the committee/duration, both of which would lose real coverage of the large-committee path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
