### PR TITLE
feat(cli): unify Terminal to drive remote benchmark runs (#170)

### DIFF
--- a/crates/cli/src/commands/local_testbed.rs
+++ b/crates/cli/src/commands/local_testbed.rs
@@ -140,11 +140,11 @@ pub async fn local_testbed(
             biased;
             _ = signal::ctrl_c() => break,
             _ = deadline.as_mut() => break,
-            _ = progress.tick() => terminal.print_status(started_at.elapsed(), None),
+            _ = progress.tick() => terminal.set_elapsed(started_at.elapsed()),
             _ = heartbeat.tick() => {
                 let snapshots = metrics.iter().map(|m| m.collect()).collect::<Vec<_>>();
-                let statistics = Some(&SnapshotAggregate::new(&snapshots));
-                terminal.print_status(started_at.elapsed(), statistics);
+                let aggregate = SnapshotAggregate::new(&snapshots);
+                terminal.print_status(started_at.elapsed(), &aggregate);
             },
         }
     }
@@ -167,7 +167,7 @@ pub async fn local_testbed(
 
     terminal.stop_progress_animation();
     eprintln!();
-    terminal.print_results(&result);
+    terminal.print_results(&result.config, &result);
     terminal.print_summary();
 
     if let Some(exporter) = &exporter {

--- a/crates/cli/src/commands/simulate.rs
+++ b/crates/cli/src/commands/simulate.rs
@@ -87,7 +87,7 @@ pub async fn simulate(
             .await
             .map_err(|error| eyre::eyre!("Simulation task panicked: {error}"))??;
 
-        terminal.print_results(&result);
+        terminal.print_results(&result.config, &result);
 
         if result.outcome == Outcome::Diverged {
             diverged += 1;

--- a/crates/cli/src/remote.rs
+++ b/crates/cli/src/remote.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-pub(crate) mod benchmark;
+mod benchmark;
 pub mod protocol;
 mod testbed;
 

--- a/crates/cli/src/remote.rs
+++ b/crates/cli/src/remote.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-mod benchmark;
+pub(crate) mod benchmark;
 pub mod protocol;
 mod testbed;
 
@@ -78,7 +78,7 @@ impl<C: ServerProviderClient + Display> RemoteTestbedDriver<C> {
                     .await
                     .wrap_err("Failed to load testbed setup commands")?;
                 let username = self.testbed.username().to_string();
-                RemoteBenchmarkDriver::new(self.settings, username, self.color)
+                RemoteBenchmarkDriver::new(self.settings, username, loads.len())
                     .benchmark(
                         instances,
                         setup_commands,

--- a/crates/cli/src/remote/benchmark.rs
+++ b/crates/cli/src/remote/benchmark.rs
@@ -18,18 +18,22 @@ use replica::result::Outcome;
 use crate::{
     exporter::Exporter,
     remote::protocol::{ClientParameters, NodeParameters, ReplicaProtocol},
-    terminal::{BannerPrinter, Terminal},
+    terminal::{BannerPrinter, OutcomeDisplay, ResultRender, Terminal, table::SuiteRow},
 };
 
-/// Final result of one remote benchmark run, as the terminal renders it.
-pub(crate) struct RemoteResult {
-    pub(crate) duration: Duration,
-    pub(crate) logs: Option<LogsReport>,
+/// Final result of one remote benchmark run, as the terminal renders it: the
+/// configured duration plus the log-analysis report (absent when log processing
+/// is disabled). Perf numbers live in the saved measurement files; the rendered
+/// block carries only the pass/warn/fail verdict derived from the logs.
+struct RemoteResult {
+    duration: Duration,
+    logs: Option<LogsReport>,
 }
 
 impl RemoteResult {
-    /// Classify the log reports.
-    pub(crate) fn outcome(&self) -> Option<Outcome> {
+    /// Classify the log report into a consensus-style [`Outcome`] for display.
+    /// `None` when logs were not collected.
+    fn outcome(&self) -> Option<Outcome> {
         let logs = self.logs.as_ref()?;
         Some(if logs.node_panic || logs.client_panic {
             Outcome::Diverged
@@ -38,6 +42,36 @@ impl RemoteResult {
         } else {
             Outcome::Pass
         })
+    }
+}
+
+impl ResultRender for RemoteResult {
+    fn render_block(&self, color: bool) -> String {
+        // Log analysis disabled: no verdict to derive, so just confirm completion.
+        let (Some(outcome), Some(logs)) = (self.outcome(), self.logs.as_ref()) else {
+            return "Benchmark complete (log analysis disabled)".to_string();
+        };
+        let mut out = outcome.badge(color);
+        if logs.node_errors != 0 || logs.client_errors != 0 {
+            out.push('\n');
+            out.push_str(&format!(
+                "Log errors — node: {}, client: {}",
+                logs.node_errors, logs.client_errors
+            ));
+        }
+        out
+    }
+
+    fn suite_row(&self, name: &str, nodes: usize) -> Option<SuiteRow> {
+        let outcome = self.outcome()?;
+        // Remote runs have no per-replica committed-leader counts to show.
+        Some(SuiteRow::new(
+            name,
+            nodes,
+            self.duration.as_secs(),
+            outcome,
+            &[],
+        ))
     }
 }
 

--- a/crates/cli/src/remote/benchmark.rs
+++ b/crates/cli/src/remote/benchmark.rs
@@ -1,35 +1,60 @@
 // Copyright (c) Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::time::Duration;
+
 use eyre::{Context, Result};
 use orchestrator::{
     benchmark::{BenchmarkParameters, Parameters},
     orchestrator::{MonitoringReport, Orchestrator},
     protocol::{ProtocolCommands, ProtocolMetrics, ProtocolParameters as _},
     provider::Instance,
-    report::TickReport,
+    report::{LogsReport, TickReport},
     session::BenchmarkSession,
     settings::Settings,
 };
+use replica::result::Outcome;
 
 use crate::{
     exporter::Exporter,
     remote::protocol::{ClientParameters, NodeParameters, ReplicaProtocol},
-    terminal::{BannerPrinter, Progress},
+    terminal::{BannerPrinter, Terminal},
 };
+
+/// Final result of one remote benchmark run, as the terminal renders it.
+pub(crate) struct RemoteResult {
+    pub(crate) duration: Duration,
+    pub(crate) logs: Option<LogsReport>,
+}
+
+impl RemoteResult {
+    /// Classify the log reports.
+    pub(crate) fn outcome(&self) -> Option<Outcome> {
+        let logs = self.logs.as_ref()?;
+        Some(if logs.node_panic || logs.client_panic {
+            Outcome::Diverged
+        } else if logs.node_errors != 0 || logs.client_errors != 0 {
+            Outcome::NoProgress
+        } else {
+            Outcome::Pass
+        })
+    }
+}
 
 pub struct RemoteBenchmarkDriver {
     settings: Settings,
     username: String,
-    progress: Progress,
+    terminal: Terminal,
 }
 
 impl RemoteBenchmarkDriver {
-    pub fn new(settings: Settings, username: String, color: bool) -> Self {
+    /// `runs` is the number of benchmarks the suite will execute (one per load),
+    /// used for the per-run heading (`[i/N]`) and the suite summary.
+    pub fn new(settings: Settings, username: String, runs: usize) -> Self {
         Self {
             settings,
             username,
-            progress: Progress::new(color),
+            terminal: Terminal::new(runs),
         }
     }
 
@@ -91,7 +116,6 @@ impl RemoteBenchmarkDriver {
             committee,
             loads,
         );
-        let total = parameters_set.len();
 
         let orchestrator = Orchestrator::new(
             self.settings.clone(),
@@ -101,20 +125,20 @@ impl RemoteBenchmarkDriver {
             &self.username,
         );
 
-        self.progress
+        self.terminal
             .track("Cleaning up testbed", orchestrator.cleanup(true))
             .await
             .wrap_err("Cleanup failed")?;
 
         if !skip_testbed_update {
-            self.progress
+            self.terminal
                 .track(
                     "Installing dependencies on all machines",
                     orchestrator.install(),
                 )
                 .await
                 .wrap_err("Install failed")?;
-            self.progress
+            self.terminal
                 .track("Updating all instances", orchestrator.update())
                 .await
                 .wrap_err("Update failed")?;
@@ -123,14 +147,9 @@ impl RemoteBenchmarkDriver {
         let mut latest_committee_size = 0;
         for (index, parameters) in parameters_set.into_iter().enumerate() {
             let benchmark_number = index + 1;
-            eprintln!();
-            eprintln!(
-                "--- Benchmark {benchmark_number}/{total}: {} ---",
-                parameters
-            );
-            eprintln!("Node parameters: {}", parameters.node_parameters);
+            self.terminal.print_config(benchmark_number, &parameters);
 
-            self.progress
+            self.terminal
                 .track("Cleaning up testbed", orchestrator.cleanup(true))
                 .await
                 .wrap_err("Cleanup failed")?;
@@ -139,7 +158,7 @@ impl RemoteBenchmarkDriver {
             // skip the call entirely rather than performing a no-op SSH round-trip.
             let monitoring = if self.settings.monitoring {
                 let report = self
-                    .progress
+                    .terminal
                     .track(
                         "Configuring monitoring instance",
                         orchestrator.start_monitoring(&parameters),
@@ -163,32 +182,29 @@ impl RemoteBenchmarkDriver {
             )
             .await?;
 
-            self.progress
+            self.terminal
                 .track("Cleaning up testbed", orchestrator.cleanup(false))
                 .await
                 .wrap_err("Cleanup failed")?;
 
-            if self.settings.log_processing {
-                let logs = self
-                    .progress
-                    .track("Downloading logs", orchestrator.download_logs(&parameters))
-                    .await
-                    .wrap_err("Failed to download logs")?;
-                if logs.node_panic {
-                    eprintln!("ERROR: node(s) panicked!");
-                } else if logs.client_panic {
-                    eprintln!("ERROR: client(s) panicked!");
-                } else if logs.node_errors != 0 || logs.client_errors != 0 {
-                    eprintln!(
-                        "WARNING: logs contain errors (node: {}, client: {})",
-                        logs.node_errors, logs.client_errors,
-                    );
-                }
-            }
+            let logs = if self.settings.log_processing {
+                Some(
+                    self.terminal
+                        .track("Downloading logs", orchestrator.download_logs(&parameters))
+                        .await
+                        .wrap_err("Failed to download logs")?,
+                )
+            } else {
+                None
+            };
+            let result = RemoteResult {
+                duration: parameters.settings.benchmark_duration,
+                logs,
+            };
+            self.terminal.print_results(&parameters, &result);
         }
 
-        eprintln!();
-        eprintln!("Benchmark completed");
+        self.terminal.print_summary();
         Ok(())
     }
 
@@ -202,7 +218,7 @@ impl RemoteBenchmarkDriver {
     ) -> Result<()> {
         if !skip_testbed_configuration && *latest_committee_size != parameters.nodes {
             let configure_report = self
-                .progress
+                .terminal
                 .track("Configuring instances", orchestrator.configure(parameters))
                 .await
                 .wrap_err("Configure failed")?;
@@ -215,7 +231,7 @@ impl RemoteBenchmarkDriver {
             *latest_committee_size = parameters.nodes;
         }
 
-        self.progress
+        self.terminal
             .track("Deploying replicas", orchestrator.run_nodes(parameters))
             .await
             .wrap_err("Deploying replicas failed")?;
@@ -229,7 +245,7 @@ impl RemoteBenchmarkDriver {
         } else {
             "Setting up load generators"
         };
-        self.progress
+        self.terminal
             .track(load_label, orchestrator.run_clients(parameters))
             .await
             .wrap_err("Starting load generators failed")?;
@@ -238,10 +254,9 @@ impl RemoteBenchmarkDriver {
             .await
     }
 
-    /// Drive the metrics + faults tick loop for a single benchmark run. Owns the
-    /// `tokio::select!`, the fault schedule, and (when monitoring is deployed) a
-    /// PromQL [`Collector`] that polls Prometheus on the metrics tick.
-    /// Drive the metrics + faults tick loop for a single benchmark run.
+    /// Drive the metrics + faults tick loop for a single benchmark run: render a
+    /// live heartbeat from the collector's scraped stats on each metrics tick,
+    /// persist each scrape's YAML, and announce fault injections.
     async fn run_benchmark_loop<P: ProtocolCommands + ProtocolMetrics>(
         &mut self,
         orchestrator: &Orchestrator<P>,
@@ -272,12 +287,17 @@ impl RemoteBenchmarkDriver {
         let exporter =
             Exporter::new(results_path).wrap_err("Failed to create results directory")?;
 
-        self.progress.start(Some(benchmark_duration), &label);
+        self.terminal
+            .start_progress_animation(Some(benchmark_duration), &label);
         let outcome = loop {
             match session.tick(orchestrator, parameters).await {
                 Err(e) => break Err(e).wrap_err("Benchmark tick failed"),
-                Ok(TickReport::MetricsTick { elapsed, results }) => {
-                    self.progress.set_elapsed(elapsed);
+                Ok(TickReport::MetricsTick {
+                    elapsed,
+                    results,
+                    stats,
+                }) => {
+                    self.terminal.print_status(elapsed, &stats);
                     if let Some(yaml) = results {
                         let key = format!("{parameters:?}");
                         let exporter_clone = exporter.clone();
@@ -296,15 +316,15 @@ impl RemoteBenchmarkDriver {
                     }
                 }
                 Ok(TickReport::FaultUpdate { elapsed, action }) => {
-                    self.progress.set_elapsed(elapsed);
+                    self.terminal.set_elapsed(elapsed);
                     if !action.kill.is_empty() || !action.boot.is_empty() {
-                        self.progress
+                        self.terminal
                             .suspend(|| eprintln!("Testbed update: {action}"));
                     }
                 }
             }
         };
-        self.progress.stop();
+        self.terminal.stop_progress_animation();
         outcome
     }
 }

--- a/crates/cli/src/terminal.rs
+++ b/crates/cli/src/terminal.rs
@@ -9,12 +9,9 @@ pub mod progress;
 mod render;
 pub mod table;
 
-use std::{io::IsTerminal, time::Duration};
+use std::{future::Future, io::IsTerminal, time::Duration};
 
-use dag::metrics::SnapshotAggregate;
-use replica::result::RunResult;
-
-pub(crate) use self::render::{AggregateRender, ConfigRender, RunResultRender};
+pub(crate) use self::render::{ConfigRender, ResultRender, StatusRender};
 use self::table::SuiteRow;
 
 pub use self::banner::BannerPrinter;
@@ -62,13 +59,14 @@ impl Terminal {
     /// [`ConfigRender::config_rows`] is empty. Callers start the progress
     /// indicator separately via [`Self::start_progress_animation`].
     pub(crate) fn print_config<C: ConfigRender>(&mut self, index: usize, config: &C) {
+        let kind = config.run_kind();
         let heading = match (self.total > 1, config.name()) {
             (true, Some(name)) => Some(format!(
-                "Simulation [{index}/{total}]: {name}",
+                "{kind} [{index}/{total}]: {name}",
                 total = self.total
             )),
-            (true, None) => Some(format!("Simulation [{index}/{total}]", total = self.total)),
-            (false, Some(name)) => Some(format!("Simulation: {name}")),
+            (true, None) => Some(format!("{kind} [{index}/{total}]", total = self.total)),
+            (false, Some(name)) => Some(format!("{kind}: {name}")),
             (false, None) => None,
         };
 
@@ -88,40 +86,30 @@ impl Terminal {
         }
     }
 
-    /// Advance the bar and optionally print the live progress line on stderr.
-    pub(crate) fn print_status(
-        &mut self,
-        elapsed: Duration,
-        aggregate: Option<&SnapshotAggregate<'_>>,
-    ) {
-        if let Some(aggregate) = aggregate {
-            self.progress
-                .suspend(|| eprintln!("{}", aggregate.render(elapsed)));
-        }
+    /// Print the live heartbeat line on stderr and advance the bar to `elapsed`.
+    /// For an advance without a line (sub-heartbeat ticks), use [`Self::set_elapsed`].
+    pub(crate) fn print_status(&mut self, elapsed: Duration, status: &impl StatusRender) {
+        self.progress
+            .suspend(|| eprintln!("{}", status.render_status_line(elapsed)));
         self.progress.set_elapsed(elapsed);
     }
 
     /// Stop the progress indicator, print the per-result block (badge + per-replica
     /// table or happy-path headline), and record the suite row for later aggregate
-    /// display.
-    pub(crate) fn print_results<C: ConfigRender>(&mut self, result: &RunResult<C>) {
+    /// display. Config and result are separate: the result owns the metrics/outcome
+    /// while the config supplies the run's name and committee size.
+    pub(crate) fn print_results(&mut self, config: &impl ConfigRender, result: &impl ResultRender) {
         self.stop_progress_animation();
-        println!("{}", result.render(self.color));
-        println!();
+        let block = result.render_block(self.color);
+        if !block.is_empty() {
+            println!("{block}");
+            println!();
+        }
 
-        let run_name = result
-            .config
-            .name()
-            .map(str::to_owned)
-            .unwrap_or_else(|| "unnamed".into());
-        let commit_counts = SnapshotAggregate::new(&result.metrics).committed_leaders_per_replica();
-        self.suite_rows.push(SuiteRow::new(
-            &run_name,
-            result.config.committee_size(),
-            result.duration.as_secs(),
-            result.outcome,
-            &commit_counts,
-        ));
+        let run_name = config.name().unwrap_or_else(|| "unnamed".into());
+        if let Some(row) = result.suite_row(&run_name, config.committee_size()) {
+            self.suite_rows.push(row);
+        }
     }
 
     /// Print the suite summary when more than one run was recorded; no-op for
@@ -151,5 +139,25 @@ impl Terminal {
     /// line with the printed text.
     pub(crate) fn stop_progress_animation(&mut self) {
         self.progress.stop();
+    }
+
+    /// Advance the determinate bar to `elapsed`. No-op for the spinner / idle.
+    pub(crate) fn set_elapsed(&self, elapsed: Duration) {
+        self.progress.set_elapsed(elapsed);
+    }
+
+    /// Run `work` under an indeterminate spinner labelled `label`, clearing it
+    /// when the future resolves. Delegates to [`Progress::track`].
+    pub(crate) async fn track<T, E, F>(&mut self, label: &str, work: F) -> Result<T, E>
+    where
+        F: Future<Output = Result<T, E>>,
+    {
+        self.progress.track(label, work).await
+    }
+
+    /// Run `f` while the active indicator is suspended (cleared, then redrawn),
+    /// so plain prints don't fight the bar for the line.
+    pub(crate) fn suspend<F: FnOnce() -> R, R>(&self, f: F) -> R {
+        self.progress.suspend(f)
     }
 }

--- a/crates/cli/src/terminal.rs
+++ b/crates/cli/src/terminal.rs
@@ -11,7 +11,7 @@ pub mod table;
 
 use std::{future::Future, io::IsTerminal, time::Duration};
 
-pub(crate) use self::render::{ConfigRender, ResultRender, StatusRender};
+pub(crate) use self::render::{ConfigRender, OutcomeDisplay, ResultRender, StatusRender};
 use self::table::SuiteRow;
 
 pub use self::banner::BannerPrinter;
@@ -112,10 +112,11 @@ impl Terminal {
         }
     }
 
-    /// Print the suite summary when more than one run was recorded; no-op for
-    /// single-run commands.
+    /// Print the suite summary when more than one run recorded a row; no-op for
+    /// single-run commands and when no run produced a row (e.g. remote benchmarks
+    /// with log analysis disabled), so we never print an empty table.
     pub(crate) fn print_summary(&self) {
-        if self.total <= 1 {
+        if self.total <= 1 || self.suite_rows.is_empty() {
             return;
         }
         println!();

--- a/crates/cli/src/terminal/render.rs
+++ b/crates/cli/src/terminal/render.rs
@@ -11,8 +11,6 @@ use std::time::Duration;
 use dag::{authority::Authority, metrics::SnapshotAggregate};
 use orchestrator::benchmark::BenchmarkParameters;
 use orchestrator::collector::LiveStats;
-
-use crate::remote::benchmark::RemoteResult;
 use replica::result::{Outcome, RunResult};
 use replica::testbed::TestbedConfig;
 use simulator::SimulationConfig;
@@ -286,35 +284,6 @@ impl<C> ResultRender for RunResult<C> {
             self.duration.as_secs(),
             self.outcome,
             &commit_counts,
-        ))
-    }
-}
-
-impl ResultRender for RemoteResult {
-    fn render_block(&self, color: bool) -> String {
-        let (Some(outcome), Some(logs)) = (self.outcome(), self.logs.as_ref()) else {
-            return String::new();
-        };
-        let mut out = outcome.badge(color);
-        if logs.node_errors != 0 || logs.client_errors != 0 {
-            out.push('\n');
-            out.push_str(&format!(
-                "Log errors — node: {}, client: {}",
-                logs.node_errors, logs.client_errors
-            ));
-        }
-        out
-    }
-
-    fn suite_row(&self, name: &str, nodes: usize) -> Option<SuiteRow> {
-        let outcome = self.outcome()?;
-        // Remote runs have no per-replica committed-leader counts to show.
-        Some(SuiteRow::new(
-            name,
-            nodes,
-            self.duration.as_secs(),
-            outcome,
-            &[],
         ))
     }
 }

--- a/crates/cli/src/terminal/render.rs
+++ b/crates/cli/src/terminal/render.rs
@@ -9,13 +9,17 @@
 use std::time::Duration;
 
 use dag::{authority::Authority, metrics::SnapshotAggregate};
+use orchestrator::benchmark::BenchmarkParameters;
+use orchestrator::collector::LiveStats;
+
+use crate::remote::benchmark::RemoteResult;
 use replica::result::{Outcome, RunResult};
 use replica::testbed::TestbedConfig;
 use simulator::SimulationConfig;
 
-use std::fmt::Write as _;
+use std::fmt::{self, Write as _};
 
-use super::table::{self, ReplicaRow};
+use super::table::{self, ReplicaRow, SuiteRow};
 use super::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 
 /// Adapter trait letting [`super::Terminal`] render any run config: the per-run
@@ -24,9 +28,13 @@ use super::{BOLD, DIM, GREEN, RED, RESET, YELLOW};
 /// renders [`Self::config_rows`] (empty means "no config to print for this
 /// command").
 pub trait ConfigRender {
-    fn name(&self) -> Option<&str>;
+    /// Per-run name shown in the heading and the suite summary's `name` column.
+    fn name(&self) -> Option<String>;
     fn committee_size(&self) -> usize;
     fn config_rows(&self) -> Vec<(&'static str, String)>;
+
+    /// Noun used in the per-run heading (`"{kind} [i/N]: {name}"`).
+    fn run_kind(&self) -> &str;
 
     /// Render `config_rows` in the banner's border-less key/value style.
     fn render(&self, color: bool) -> String {
@@ -43,8 +51,12 @@ pub trait ConfigRender {
 }
 
 impl ConfigRender for SimulationConfig {
-    fn name(&self) -> Option<&str> {
-        self.name.as_deref()
+    fn name(&self) -> Option<String> {
+        self.name.clone()
+    }
+
+    fn run_kind(&self) -> &str {
+        "Simulation"
     }
 
     fn committee_size(&self) -> usize {
@@ -67,8 +79,12 @@ impl ConfigRender for SimulationConfig {
 }
 
 impl ConfigRender for TestbedConfig {
-    fn name(&self) -> Option<&str> {
+    fn name(&self) -> Option<String> {
         None
+    }
+
+    fn run_kind(&self) -> &str {
+        "Testbed"
     }
 
     fn committee_size(&self) -> usize {
@@ -78,6 +94,33 @@ impl ConfigRender for TestbedConfig {
     fn config_rows(&self) -> Vec<(&'static str, String)> {
         // Configs are already printed in the banner.
         vec![]
+    }
+}
+
+impl<N: fmt::Display, C> ConfigRender for BenchmarkParameters<N, C> {
+    fn name(&self) -> Option<String> {
+        // The suite-summary `name` column needs a per-run identity; benchmarks
+        // carry theirs in the `Display` impl (`"N nodes (faults) - L tx/s"`).
+        Some(self.to_string())
+    }
+
+    fn run_kind(&self) -> &str {
+        "Benchmark"
+    }
+
+    fn committee_size(&self) -> usize {
+        self.nodes
+    }
+
+    fn config_rows(&self) -> Vec<(&'static str, String)> {
+        // Committee size and commit are already printed in the banner; surface the
+        // per-benchmark knobs (load, fault schedule, node parameters) that vary
+        // across the suite.
+        vec![
+            ("Load", format!("{} tx/s", self.load)),
+            ("Faults", self.settings.faults.to_string()),
+            ("Node parameters", self.node_parameters.to_string()),
+        ]
     }
 }
 
@@ -123,52 +166,21 @@ impl OutcomeDisplay for Outcome {
     }
 }
 
-/// Per-result display block: outcome badge followed by either a one-line happy-path
-/// summary or the full per-replica table.
-pub trait RunResultRender {
-    fn render(&self, color: bool) -> String;
+/// Live heartbeat renderer, driven by [`super::Terminal::print_status`] on each
+/// progress tick. Implemented by the transient live-metrics views — the local
+/// per-replica aggregate and the remote Prometheus-scraped stats — not by a
+/// finished run (no result/verdict exists mid-run).
+pub trait StatusRender {
+    /// Heartbeat one-liner, e.g.
+    /// `[t=Ns] · committed=N · X.X commits/s · Y tx/s · p50 N ms · p90 N ms`.
+    /// Sub-fields are omitted when the underlying aggregator returns `None` (e.g.
+    /// before the load generator's `initial_delay` has elapsed and the latency
+    /// histogram is still empty).
+    fn render_status_line(&self, elapsed: Duration) -> String;
 }
 
-impl<C> RunResultRender for RunResult<C> {
-    fn render(&self, color: bool) -> String {
-        let outcome = self.outcome;
-        let aggregate = SnapshotAggregate::new(&self.metrics);
-        let commit_counts = aggregate.committed_leaders_per_replica();
-
-        let mut out = outcome.badge(color);
-        out.push('\n');
-
-        let uniform_commits = commit_counts
-            .first()
-            .map(|first| commit_counts.iter().all(|c| c == first))
-            .unwrap_or(true);
-        if outcome != Outcome::Diverged && uniform_commits {
-            out.push_str(&aggregate.render(self.duration));
-        } else {
-            let rows = self
-                .metrics
-                .iter()
-                .enumerate()
-                .map(move |(index, metrics)| {
-                    ReplicaRow::new(Authority::from(index), self.duration, metrics)
-                });
-            out.push_str(&table::render(rows));
-        }
-        out
-    }
-}
-
-/// Live one-line render of an aggregate, e.g.
-/// `[t=Ns] · committed=N · X.X commits/s · Y tx/s · p50 N ms · p90 N ms`.
-/// Sub-fields are omitted when the underlying aggregator returns `None` (e.g. before
-/// the load generator's `initial_delay` has elapsed and the latency histogram is
-/// still empty).
-pub trait AggregateRender {
-    fn render(&self, elapsed: Duration) -> String;
-}
-
-impl AggregateRender for SnapshotAggregate<'_> {
-    fn render(&self, elapsed: Duration) -> String {
+impl StatusRender for SnapshotAggregate<'_> {
+    fn render_status_line(&self, elapsed: Duration) -> String {
         let mut parts = vec![
             format!("[t={}s]", fixed_length_format(elapsed.as_secs() as f64)),
             format!(
@@ -198,6 +210,112 @@ impl AggregateRender for SnapshotAggregate<'_> {
             parts.push(format!("p90={}ms", fixed_length_format(p90)));
         }
         parts.join(" · ")
+    }
+}
+
+impl StatusRender for LiveStats {
+    fn render_status_line(&self, elapsed: Duration) -> String {
+        // Keys match the metric names `ReplicaProtocol` registers and the
+        // collector's `{name}.p{quantile}` convention for histogram quantiles.
+        // `latency_s_count` is the per-second rate of latency observations — one
+        // per committed transaction — i.e. throughput; quantiles are in seconds.
+        let mut parts = vec![format!(
+            "[t={}s]",
+            fixed_length_format(elapsed.as_secs() as f64)
+        )];
+        if let Some(tps) = self.get("latency_s_count") {
+            parts.push(format!("tx/s={}", fixed_length_format(tps)));
+        }
+        if let Some(p50) = self.get("latency_s.p50") {
+            parts.push(format!("p50={}ms", fixed_length_format(p50 * 1000.0)));
+        }
+        if let Some(p90) = self.get("latency_s.p90") {
+            parts.push(format!("p90={}ms", fixed_length_format(p90 * 1000.0)));
+        }
+        parts.join(" · ")
+    }
+}
+
+/// Final-result renderer, driven by [`super::Terminal::print_results`] once a run
+/// finishes. Implemented by the end-of-run result types (`RunResult`, the remote
+/// benchmark result).
+pub trait ResultRender {
+    /// Per-result block: outcome badge followed by a happy-path one-liner or the
+    /// full per-replica table. Empty string means "nothing to print".
+    fn render_block(&self, color: bool) -> String;
+
+    /// One row for the suite summary table, given the per-run `name` and committee
+    /// size resolved from the config. `None` contributes no row — used by results
+    /// whose outcome could not be determined.
+    fn suite_row(&self, name: &str, nodes: usize) -> Option<SuiteRow>;
+}
+
+impl<C> ResultRender for RunResult<C> {
+    fn render_block(&self, color: bool) -> String {
+        let outcome = self.outcome;
+        let aggregate = SnapshotAggregate::new(&self.metrics);
+        let commit_counts = aggregate.committed_leaders_per_replica();
+
+        let mut out = outcome.badge(color);
+        out.push('\n');
+
+        let uniform_commits = commit_counts
+            .first()
+            .map(|first| commit_counts.iter().all(|c| c == first))
+            .unwrap_or(true);
+        if outcome != Outcome::Diverged && uniform_commits {
+            out.push_str(&aggregate.render_status_line(self.duration));
+        } else {
+            let rows = self
+                .metrics
+                .iter()
+                .enumerate()
+                .map(move |(index, metrics)| {
+                    ReplicaRow::new(Authority::from(index), self.duration, metrics)
+                });
+            out.push_str(&table::render(rows));
+        }
+        out
+    }
+
+    fn suite_row(&self, name: &str, nodes: usize) -> Option<SuiteRow> {
+        let commit_counts = SnapshotAggregate::new(&self.metrics).committed_leaders_per_replica();
+        Some(SuiteRow::new(
+            name,
+            nodes,
+            self.duration.as_secs(),
+            self.outcome,
+            &commit_counts,
+        ))
+    }
+}
+
+impl ResultRender for RemoteResult {
+    fn render_block(&self, color: bool) -> String {
+        let (Some(outcome), Some(logs)) = (self.outcome(), self.logs.as_ref()) else {
+            return String::new();
+        };
+        let mut out = outcome.badge(color);
+        if logs.node_errors != 0 || logs.client_errors != 0 {
+            out.push('\n');
+            out.push_str(&format!(
+                "Log errors — node: {}, client: {}",
+                logs.node_errors, logs.client_errors
+            ));
+        }
+        out
+    }
+
+    fn suite_row(&self, name: &str, nodes: usize) -> Option<SuiteRow> {
+        let outcome = self.outcome()?;
+        // Remote runs have no per-replica committed-leader counts to show.
+        Some(SuiteRow::new(
+            name,
+            nodes,
+            self.duration.as_secs(),
+            outcome,
+            &[],
+        ))
     }
 }
 

--- a/crates/orchestrator/src/collector.rs
+++ b/crates/orchestrator/src/collector.rs
@@ -15,7 +15,7 @@
 //! by labels post-hoc.
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     fs,
     path::{Path, PathBuf},
 };
@@ -87,6 +87,60 @@ pub struct BenchmarkResults<N, C> {
 impl<N: Serialize, C: Serialize> BenchmarkResults<N, C> {
     pub fn to_yaml(&self) -> String {
         serde_yaml::to_string(self).expect("BenchmarkResults always serialises to YAML")
+    }
+}
+
+impl<N, C> BenchmarkResults<N, C> {
+    /// Snapshot the most recent scrape as one value per metric key, for a live
+    /// heartbeat. Each PromQL query is already windowed (`rate(..[RATE_WINDOW])`,
+    /// `histogram_quantile(.., rate(..[RATE_WINDOW]))`), so the latest sample is
+    /// the last-window throughput / quantile — no run-to-date averaging. A scrape
+    /// stores one sample per series (e.g. per node) sharing one instant-query
+    /// timestamp, so we take the max-timestamp group and average it across series
+    /// into a single cluster figure.
+    pub fn live_stats(&self) -> LiveStats {
+        let values = self
+            .samples
+            .iter()
+            .filter_map(|(key, samples)| {
+                let latest_timestamp = samples
+                    .iter()
+                    .map(|sample| sample.timestamp)
+                    .fold(f64::NEG_INFINITY, f64::max);
+                let latest: Vec<f64> = samples
+                    .iter()
+                    .filter(|sample| sample.timestamp == latest_timestamp)
+                    .map(|sample| sample.value)
+                    .collect();
+                if latest.is_empty() {
+                    return None;
+                }
+                Some((
+                    key.clone(),
+                    latest.iter().sum::<f64>() / latest.len() as f64,
+                ))
+            })
+            .collect();
+        LiveStats { values }
+    }
+}
+
+/// Point-in-time snapshot of the collected metrics: the most recent scrape value
+/// per metric key (throughput rates and histogram quantiles), averaged across
+/// series. Non-generic so it can ride on [`crate::report::TickReport`] without
+/// leaking the protocol parameter types; the consumer interprets the keys (e.g.
+/// the CLI maps `latency_s.p50` → p50 latency).
+#[derive(Clone, Debug, Default)]
+pub struct LiveStats {
+    values: BTreeMap<String, f64>,
+}
+
+impl LiveStats {
+    /// Latest value for `key`, or `None` if no samples landed under it. Keys follow
+    /// the collector's storage convention: a bare metric name for counters/gauges,
+    /// `{name}.p{quantile}` for histogram quantiles.
+    pub fn get(&self, key: &str) -> Option<f64> {
+        self.values.get(key).copied()
     }
 }
 

--- a/crates/orchestrator/src/report.rs
+++ b/crates/orchestrator/src/report.rs
@@ -3,7 +3,7 @@
 
 use std::{net::SocketAddr, time::Duration};
 
-use crate::{faults::CrashRecoveryAction, provider::Instance};
+use crate::{collector::LiveStats, faults::CrashRecoveryAction, provider::Instance};
 
 /// Per-instance addresses produced by [`crate::orchestrator::Orchestrator::configure`].
 /// The caller uses this to render the "Configuring instances" table;
@@ -54,14 +54,15 @@ pub struct LogsReport {
 }
 
 /// One iteration of the benchmark tick loop. Future return type of
-/// `Orchestrator::tick()` (issue #172).
+/// `Orchestrator::tick()`.
 pub enum TickReport {
-    /// A metrics scrape interval fired. `results` contains the YAML-serialised
-    /// snapshot of the accumulated `BenchmarkResults` when a Prometheus collector
-    /// is active.
+    /// A metrics scrape interval fired. When a Prometheus collector is active,
+    /// `results` carries the YAML-serialised snapshot of the accumulated
+    /// `BenchmarkResults` (for on-disk persistence).
     MetricsTick {
         elapsed: Duration,
         results: Option<String>,
+        stats: LiveStats,
     },
     /// A fault-schedule interval fired and the orchestrator killed or rebooted
     /// instances accordingly.

--- a/crates/orchestrator/src/session.rs
+++ b/crates/orchestrator/src/session.rs
@@ -78,9 +78,15 @@ impl<P: ProtocolCommands + ProtocolMetrics> BenchmarkSession<P> {
                     collector.collect().await?;
                 }
                 let results = self.collector.as_ref().map(|c| c.results().to_yaml());
+                let stats = self
+                    .collector
+                    .as_ref()
+                    .map(|c| c.results().live_stats())
+                    .unwrap_or_default();
                 Ok(TickReport::MetricsTick {
                     elapsed: self.start.elapsed(),
                     results,
+                    stats,
                 })
             }
             _ = self.faults_interval.tick() => {


### PR DESCRIPTION
## Context

`Terminal` (`crates/cli/src/terminal`) already drives the full output lifecycle for
`local-testbed` and `simulate`: progress bar/spinner, config display, live heartbeat,
per-result block, and suite summary. The remote benchmark driver bypassed all of it,
holding a bare `Progress` and emitting ad-hoc `eprintln!`s. This unifies remote runs onto
the same `Terminal`, closing #170.

## What changed

**Renderer split into two traits** (`terminal/render.rs`):
- `StatusRender` — the live heartbeat line. Impl'd by `SnapshotAggregate` (local) and the
  new `LiveStats` (remote).
- `ResultRender` — final per-result block + suite-summary row. Impl'd by `RunResult`
  (local/sim) and `RemoteResult` (remote).

`ConfigRender` gains `run_kind()` (so headings read `Benchmark [i/N]` vs `Simulation`) and
an owned `name()`, plus a `BenchmarkParameters` impl. `Terminal::print_status`/
`print_results` now take these traits; `track`/`suspend`/`set_elapsed` delegators let the
driver own a single `Terminal`.

**Remote live heartbeat** — a new orchestrator `LiveStats` snapshot (latest-scrape value
per metric key, averaged across nodes) rides on `TickReport::MetricsTick`. The collector
stays protocol-agnostic (a `key → value` map); the CLI interprets the keys.

**`RemoteBenchmarkDriver`** now owns a `Terminal` and routes config heading, per-scrape
heartbeat, results, and suite summary through it; raw `eprintln!` remains only where no
spinner is active (warnings, Grafana URL, node/client addresses).

## Notes
- Small behavior addition: the per-benchmark config rows now include the fault schedule.
- The remote heartbeat reads metric keys (`latency_s_count`, `latency_s.p50/.p90`) as a
  stringly-typed contract across `ReplicaProtocol::metrics()`, the collector's `.pXX`
  convention, and `render.rs`. Correct today; a candidate follow-up is to share these as
  constants so a rename breaks the build.

## Verification
`cargo build`, `cargo clippy --workspace --all-targets`, `cargo test` (workspace), and
`cargo fmt` all pass. Verified `local-testbed` and `simulate` render identically by
running both. Remote can't run without a cloud testbed; its path is compile- and
review-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
