### PR TITLE
ci: skip *_n20 scenario tests in the coverage run

### DIFF
--- a/.github/workflows/code.yaml
+++ b/.github/workflows/code.yaml
@@ -83,7 +83,7 @@ jobs:
             --exclude-files "crates/**/benches/**/*" \
             --exclude-files "crates/**/tests/**/*" \
             --exclude-files "crates/**/test_utils/**/*" \
-            -- --include-ignored
+            -- --include-ignored --skip n20
   dependencies:
     name: Check dependencies
     needs: diff


### PR DESCRIPTION
## Problem

The `Test coverage` job (`cargo tarpaulin`, main-only) keeps timing out. Raising `--timeout` to 180s (#176) wasn't enough: the heavy `*_n20` scenario tests still exceed tarpaulin's per-test watchdog under instrumentation, and bumping the number further is whack-a-mole (four tests share the pattern: `indirect_skip`, `indirect_commit`, `direct_skip`, `no_leader`).

## Why these tests are slow (investigated, not guessed)

- Measured `indirect_skip_n20`: **13s release / 135s debug**; tarpaulin (debug + ptrace) pushes it past 180s.
- It's **CPU-bound, not I/O**: `/usr/bin/time -l` showed 99% user CPU, 0 block I/O ops, 0 voluntary context switches — the WAL/tempfile is buffered and never blocks. A sampling profile put the cost in **in-memory block-store `get_block` lookups (SipHash over digest keys) + per-block `bincode` serialize-for-digest**.
- Each `*_n20` test is really ~300 independent scenarios (`all_for_test` protocol matrix × a `0..k` leader-offset sweep) run **serially in one `#[test]`**.

## Fix

Skip the `*_n20` variants in the **coverage run only**: append `--skip n20` to the tarpaulin test args.

This is safe and loses no coverage:
- These are integration tests, already excluded from coverage *reporting* (`--exclude-files crates/**/tests/**`); they drive coverage of `consensus`/`simulator` **`src`**, and their `n4`/`n9` siblings hit the **same `src` lines** at smaller committee size.
- The `n20` variants are correctness-at-scale checks — they **still run** (fast: seconds) in the `Test Rust code` nextest job.

So coverage of `src` is unchanged, correctness coverage is unchanged, and the coverage job stops timing out. `--timeout 180` is kept as harmless headroom for the remaining (smaller) tests.

Follow-up tracked separately: the monolithic-test structure that makes these slow and non-parallel (won't scale as protocols are added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
