### PR TITLE
docs: link Orcaella paper and tidy README quick-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ This repository currently supports [Mysticeti](https://sonnino.com/papers/mystic
 [Mahi-Mahi](https://sonnino.com/papers/mahi-mahi.pdf),
 [Blue Bottle](https://sonnino.com/papers/bluebottle.pdf), [Cordial
 Miners](https://arxiv.org/abs/2205.09174) (both the partially synchronous and asynchronous
-variants), and [Nemo-Nemo](https://sonnino.com/papers/nemo-nemo.pdf).
+variants), [Nemo-Nemo](https://sonnino.com/papers/nemo-nemo.pdf), and [Orcaella](https://sonnino.com/papers/orcaella.pdf).
 
 ## Quick Start
 
 To boot a local testbed of 4 replicas with a built-in load generator on your machine:
 
-```
-$ git clone https://github.com/asonnino/mysticeti.git
-$ cd mysticeti
-$ cargo run local-testbed
+```bash
+git clone https://github.com/asonnino/mysticeti.git
+cd mysticeti
+cargo run local-testbed
 ```
 
 The testbed runs for 20 seconds by default and prints a per-replica summary on exit. Pass

--- a/crates/consensus/src/protocol.rs
+++ b/crates/consensus/src/protocol.rs
@@ -333,7 +333,7 @@ impl Protocol {
     /// Orcaella
     ///
     /// "Orcaella: Hybrid Fault Tolerance with Client-Selectable Finality Latency"
-    /// <TBD>
+    /// <https://sonnino.com/papers/orcaella.pdf>
     pub fn orcaella(
         total_stake: Stake,
         f: Stake,


### PR DESCRIPTION
## Summary
- List Orcaella among the supported protocols in the README, with a link to its paper
- Replace the `<TBD>` placeholder in `Protocol::orcaella` docs with the actual paper URL
- Tidy the README quick-start snippet: `bash` syntax highlighting and no `$` prompts, so the block is copy-pasteable

🤖 Generated with [Claude Code](https://claude.com/claude-code)