### PR TITLE
feat(consensus): split committer quorum roles and add fast-path seams

### DIFF
--- a/crates/consensus/src/base.rs
+++ b/crates/consensus/src/base.rs
@@ -256,18 +256,16 @@ impl BaseCommitter {
         LeaderStatus::IndirectSkip(leader, leader_round)
     }
 
-    /// Check whether the specified leader has enough blames (`direct_skip_quorum` non-votes)
-    /// to be directly skipped.
+    /// Check whether the specified leader has enough blames (`direct_skip_quorum` non-votes
+    /// among the voting-round blocks) to be directly skipped.
     fn enough_leader_blame(
         &self,
-        voting_round: RoundNumber,
+        voting_blocks: &[Data<Block>],
         leader: Authority,
         leader_round: RoundNumber,
     ) -> bool {
-        let voting_blocks = self.block_reader.get_blocks_by_round(voting_round);
-
         let mut aggregator = StakeAggregator::new(self.direct_skip_quorum);
-        for voting_block in &voting_blocks {
+        for voting_block in voting_blocks {
             let voter = voting_block.reference().authority;
             if self
                 .find_support((leader, leader_round), voting_block)
@@ -306,21 +304,18 @@ impl BaseCommitter {
         false
     }
 
-    /// Check whether the specified leader has enough votes at the voting round
-    /// (`fast_path.commit_quorum`) to be fast-committed. Always false for protocols
-    /// without a fast path.
+    /// Check whether the specified leader has enough votes at the voting round to be
+    /// fast-committed. Always false for protocols without a fast path.
     fn enough_fast_path_support(
         &self,
-        voting_round: RoundNumber,
+        voting_blocks: &[Data<Block>],
         leader_block: &Data<Block>,
     ) -> bool {
         let Some(fast_path) = &self.fast_path else {
             return false;
         };
-        let voting_blocks = self.block_reader.get_blocks_by_round(voting_round);
-
         let mut votes_stake_aggregator = StakeAggregator::new(fast_path.commit_quorum);
-        for voting_block in &voting_blocks {
+        for voting_block in voting_blocks {
             let authority = voting_block.reference().authority;
             if self.is_vote(voting_block, leader_block)
                 && votes_stake_aggregator.add(authority, &self.committee)
@@ -381,10 +376,12 @@ impl BaseCommitter {
         let voting_round = self.wave.voting_round(wave);
         let decision_round = self.wave.decision_round(wave);
 
+        let voting_blocks = self.block_reader.get_blocks_by_round(voting_round);
+
         // Check whether the leader has enough blame. That is, whether there are
         // `direct_skip_quorum` non-votes for that leader (which ensure there will never
         // be a certificate for that leader).
-        if self.enough_leader_blame(voting_round, leader, leader_round) {
+        if self.enough_leader_blame(&voting_blocks, leader, leader_round) {
             return LeaderStatus::DirectSkip(leader, leader_round);
         }
 
@@ -396,7 +393,7 @@ impl BaseCommitter {
             .block_reader
             .get_blocks_at_authority_round(leader, leader_round);
         let mut supported = leader_blocks.into_iter().filter(|leader_block| {
-            self.enough_fast_path_support(voting_round, leader_block)
+            self.enough_fast_path_support(&voting_blocks, leader_block)
                 || self.enough_leader_support(decision_round, leader_block)
         });
         let first = supported.next();
@@ -612,7 +609,8 @@ mod tests {
 
         let committer =
             BaseCommitter::new_for_test(&committee, storage.block_reader().clone(), 3, 0);
-        assert!(committer.enough_leader_blame(4, leader, leader_round));
+        let voting_blocks = storage.block_reader().get_blocks_by_round(4);
+        assert!(committer.enough_leader_blame(&voting_blocks, leader, leader_round));
     }
 
     /// `enough_leader_support` is `true` for a fully-connected DAG.

--- a/crates/consensus/src/base.rs
+++ b/crates/consensus/src/base.rs
@@ -6,7 +6,11 @@ use std::{
     sync::Arc,
 };
 
-use crate::{leader::LeaderElector, protocol::Protocol, wave::Wave};
+use crate::{
+    leader::LeaderElector,
+    protocol::{FastPath, Protocol},
+    wave::Wave,
+};
 use dag::{
     authority::Authority,
     block::{Block, BlockReference, RoundNumber},
@@ -29,6 +33,8 @@ pub(crate) struct BaseCommitter {
     leader_elector: LeaderElector,
     direct_commit_quorum: Stake,
     direct_skip_quorum: Stake,
+    certificate_quorum: Stake,
+    fast_path: Option<FastPath>,
     anchor_link_size: Stake,
     pub(crate) wave: Wave,
     leader_offset: RoundNumber,
@@ -49,6 +55,8 @@ impl BaseCommitter {
             leader_elector,
             direct_commit_quorum: protocol.direct_commit_quorum,
             direct_skip_quorum: protocol.direct_skip_quorum,
+            certificate_quorum: protocol.certificate_quorum,
+            fast_path: protocol.fast_path,
             anchor_link_size: protocol.anchor_link_size,
             wave: Wave::new(protocol.wave_length, round_offset),
             leader_offset,
@@ -63,9 +71,13 @@ impl BaseCommitter {
         leader_offset: RoundNumber,
     ) -> Self {
         let total = committee.total_stake();
+        let quorum = 2 * total / 3 + 1;
         let protocol = Protocol {
-            direct_commit_quorum: 2 * total / 3 + 1,
-            direct_skip_quorum: 2 * total / 3 + 1,
+            direct_commit_quorum: quorum,
+            direct_skip_quorum: quorum,
+            certificate_quorum: quorum,
+            quorum_threshold: quorum,
+            fast_path: None,
             anchor_link_size: 1,
             wave_length,
             leader_count: std::num::NonZeroUsize::new(1).unwrap(),
@@ -81,6 +93,13 @@ impl BaseCommitter {
             leader_offset,
             0,
         )
+    }
+
+    /// Enable the optimistic fast path on a test committer.
+    #[cfg(test)]
+    fn with_fast_path(mut self, fast_path: FastPath) -> Self {
+        self.fast_path = Some(fast_path);
+        self
     }
 
     /// The leader-elect protocol is offset by `leader_offset` to ensure that different
@@ -146,7 +165,7 @@ impl BaseCommitter {
             return self.is_vote(potential_certificate, leader_block);
         }
 
-        let mut votes_stake_aggregator = StakeAggregator::new(self.direct_commit_quorum);
+        let mut votes_stake_aggregator = StakeAggregator::new(self.certificate_quorum);
         for reference in potential_certificate.includes() {
             let potential_vote = self
                 .block_reader
@@ -166,8 +185,10 @@ impl BaseCommitter {
         false
     }
 
-    /// Decide the status of a target leader from the specified anchor. We commit the target leader
-    /// if it has a certified link to the anchor. Otherwise, we skip the target leader.
+    /// Decide the status of a target leader from the specified anchor, applying the
+    /// graded indirect rule: commit the leader block with a certified link to the
+    /// anchor (unique); else, for fast-path protocols, commit the leader block backed
+    /// by a weak quorum of anchor-linked votes; else skip the target leader.
     fn decide_leader_from_anchor(
         &self,
         anchor: &Data<Block>,
@@ -187,7 +208,7 @@ impl BaseCommitter {
         let decision_blocks = self.block_reader.get_blocks_by_round(decision_round);
 
         // Find the certified leader block (at most one).
-        let mut certified = leader_blocks.into_iter().filter(|leader_block| {
+        let mut certified = leader_blocks.iter().filter(|leader_block| {
             let mut aggregator = StakeAggregator::new(self.anchor_link_size);
             decision_blocks.iter().any(|block| {
                 if !self.block_reader.linked(anchor, block) {
@@ -205,10 +226,34 @@ impl BaseCommitter {
         }
 
         tracing::trace!("[{self}] leader {leader} is decided by anchor {anchor:?}");
-        match first {
-            Some(block) => LeaderStatus::IndirectCommit(block.clone()),
-            None => LeaderStatus::IndirectSkip(leader, leader_round),
+        if let Some(block) = first {
+            return LeaderStatus::IndirectCommit(block.clone());
         }
+
+        // Second rung (fast-path protocols only): commit the leader block backed by a
+        // weak quorum of votes linked to the anchor. Unlike the certificate rung, two
+        // equivocating leader blocks can both qualify (a slow commit does not starve
+        // conflicts of votes), so ties are broken deterministically.
+        if let Some(fast_path) = &self.fast_path {
+            let voting_round = self.wave.voting_round(wave);
+            let voting_blocks = self.block_reader.get_blocks_by_round(voting_round);
+            let weak_commit = leader_blocks
+                .into_iter()
+                .filter(|leader_block| {
+                    let mut aggregator = StakeAggregator::new(fast_path.weak_indirect_quorum);
+                    voting_blocks.iter().any(|block| {
+                        self.block_reader.linked(anchor, block)
+                            && self.is_vote(block, leader_block)
+                            && aggregator.add(block.author(), &self.committee)
+                    })
+                })
+                .min_by_key(|leader_block| leader_block.reference().digest);
+            if let Some(block) = weak_commit {
+                return LeaderStatus::IndirectCommit(block);
+            }
+        }
+
+        LeaderStatus::IndirectSkip(leader, leader_round)
     }
 
     /// Check whether the specified leader has enough blames (`direct_skip_quorum` non-votes)
@@ -254,6 +299,31 @@ impl BaseCommitter {
             let authority = decision_block.reference().authority;
             if self.is_certificate(decision_block, leader_block)
                 && certificate_stake_aggregator.add(authority, &self.committee)
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Check whether the specified leader has enough votes at the voting round
+    /// (`fast_path.commit_quorum`) to be fast-committed. Always false for protocols
+    /// without a fast path.
+    fn enough_fast_path_support(
+        &self,
+        voting_round: RoundNumber,
+        leader_block: &Data<Block>,
+    ) -> bool {
+        let Some(fast_path) = &self.fast_path else {
+            return false;
+        };
+        let voting_blocks = self.block_reader.get_blocks_by_round(voting_round);
+
+        let mut votes_stake_aggregator = StakeAggregator::new(fast_path.commit_quorum);
+        for voting_block in &voting_blocks {
+            let authority = voting_block.reference().authority;
+            if self.is_vote(voting_block, leader_block)
+                && votes_stake_aggregator.add(authority, &self.committee)
             {
                 return true;
             }
@@ -318,15 +388,17 @@ impl BaseCommitter {
             return LeaderStatus::DirectSkip(leader, leader_round);
         }
 
-        // Check whether the leader(s) has enough support. That is, whether there are
-        // `direct_commit_quorum` certificates over the leader. Note that there could be
-        // more than one leader block (created by Byzantine leaders).
+        // Check whether the leader(s) has enough support: `fast_path.commit_quorum`
+        // votes at the voting round (fast path, when configured) or
+        // `direct_commit_quorum` certificates at the decision round. Note that there
+        // could be more than one leader block (created by Byzantine leaders).
         let leader_blocks = self
             .block_reader
             .get_blocks_at_authority_round(leader, leader_round);
-        let mut supported = leader_blocks
-            .into_iter()
-            .filter(|l| self.enough_leader_support(decision_round, l));
+        let mut supported = leader_blocks.into_iter().filter(|leader_block| {
+            self.enough_fast_path_support(voting_round, leader_block)
+                || self.enough_leader_support(decision_round, leader_block)
+        });
         let first = supported.next();
         if supported.next().is_some() {
             panic!(
@@ -362,7 +434,7 @@ mod tests {
         test_util::{build_dag, build_dag_layer, committee},
     };
 
-    use crate::base::BaseCommitter;
+    use crate::{base::BaseCommitter, protocol::FastPath};
 
     /// `elect_leader` returns `None` outside leader rounds.
     #[test]
@@ -632,6 +704,113 @@ mod tests {
                 assert_eq!(round, 3);
             }
             other => panic!("expected Undecided, got {other:?}"),
+        }
+    }
+
+    /// With a fast path, a quorum of votes at the voting round direct-commits the
+    /// leader even though the decision round is absent; without a fast path the same
+    /// DAG stays `Undecided`.
+    #[test]
+    fn try_direct_decide_fast_commits_at_voting_round() {
+        let committee = committee(4);
+        let mut storage = Storage::new_for_test(&committee);
+        // DAG stops at the voting round: votes exist, certificates cannot.
+        build_dag(&committee, &mut storage, None, 4);
+
+        let fast_committer =
+            BaseCommitter::new_for_test(&committee, storage.block_reader().clone(), 3, 0)
+                .with_fast_path(FastPath {
+                    commit_quorum: 3,
+                    weak_indirect_quorum: 2,
+                });
+        let slow_committer =
+            BaseCommitter::new_for_test(&committee, storage.block_reader().clone(), 3, 0);
+
+        let leader = fast_committer.elect_leader(3).unwrap();
+        match fast_committer.try_direct_decide(leader, 3) {
+            LeaderStatus::DirectCommit(block) => assert_eq!(block.author(), leader),
+            other => panic!("expected DirectCommit, got {other:?}"),
+        }
+        match slow_committer.try_direct_decide(leader, 3) {
+            LeaderStatus::Undecided(authority, round) => {
+                assert_eq!(authority, leader);
+                assert_eq!(round, 3);
+            }
+            other => panic!("expected Undecided, got {other:?}"),
+        }
+    }
+
+    /// With no certificate at the decision round, a weak quorum of anchor-linked votes
+    /// indirect-commits the leader (second rung of the graded rule); without a fast
+    /// path the same DAG indirect-skips.
+    #[test]
+    fn decide_leader_from_anchor_weak_quorum_commits() {
+        let committee = committee(4);
+        let mut storage = Storage::new_for_test(&committee);
+
+        let leader_round = 3;
+        let references_at_leader = build_dag(&committee, &mut storage, None, leader_round);
+        // Round-robin: round 3 → authority 3.
+        let leader = committee.authorities().nth(3).unwrap();
+        let references_without_leader: Vec<_> = references_at_leader
+            .iter()
+            .copied()
+            .filter(|reference| reference.authority != leader)
+            .collect();
+
+        // Voting round: authorities 0 and 1 vote for the leader; 2 and 3 blame it.
+        // Two votes clear the weak quorum (2) but not the certificate quorum (3).
+        let voters = [
+            committee.authorities().next().unwrap(),
+            committee.authorities().nth(1).unwrap(),
+        ];
+        let voting_connections = committee
+            .authorities()
+            .map(|authority| {
+                let parents = if voters.contains(&authority) {
+                    references_at_leader.clone()
+                } else {
+                    references_without_leader.clone()
+                };
+                (authority, parents)
+            })
+            .collect();
+        let references_at_voting_round = build_dag_layer(voting_connections, &mut storage);
+
+        // Decision and anchor rounds are fully connected: every decision block carries
+        // only the two votes (no certificate) and the anchor links every voting block.
+        build_dag(
+            &committee,
+            &mut storage,
+            Some(references_at_voting_round),
+            6,
+        );
+        let anchor = storage
+            .block_reader()
+            .get_blocks_at_authority_round(committee.authorities().next().unwrap(), 6)
+            .into_iter()
+            .next()
+            .unwrap();
+
+        let fast_committer =
+            BaseCommitter::new_for_test(&committee, storage.block_reader().clone(), 3, 0)
+                .with_fast_path(FastPath {
+                    commit_quorum: 3,
+                    weak_indirect_quorum: 2,
+                });
+        let slow_committer =
+            BaseCommitter::new_for_test(&committee, storage.block_reader().clone(), 3, 0);
+
+        match fast_committer.decide_leader_from_anchor(&anchor, leader, leader_round) {
+            LeaderStatus::IndirectCommit(block) => assert_eq!(block.author(), leader),
+            other => panic!("expected IndirectCommit, got {other:?}"),
+        }
+        match slow_committer.decide_leader_from_anchor(&anchor, leader, leader_round) {
+            LeaderStatus::IndirectSkip(authority, round) => {
+                assert_eq!(authority, leader);
+                assert_eq!(round, leader_round);
+            }
+            other => panic!("expected IndirectSkip, got {other:?}"),
         }
     }
 

--- a/crates/consensus/src/committer.rs
+++ b/crates/consensus/src/committer.rs
@@ -24,8 +24,12 @@ use dag::storage::Storage;
 pub struct Committer {
     block_reader: BlockReader,
     base_committers: Vec<BaseCommitter>,
-    direct_commit_quorum: Stake,
+    quorum_threshold: Stake,
     leader_wait: bool,
+    /// Whether the protocol has an optimistic fast path; drives the test-only
+    /// round-depth queries.
+    #[cfg(any(test, feature = "test-utils"))]
+    has_fast_path: bool,
     /// Reusable buffer for commit decisions.
     leaders: VecDeque<LeaderStatus>,
 }
@@ -56,8 +60,10 @@ impl Committer {
         Self {
             block_reader,
             base_committers,
-            direct_commit_quorum: protocol.direct_commit_quorum,
+            quorum_threshold: protocol.quorum_threshold,
             leader_wait: protocol.leader_wait,
+            #[cfg(any(test, feature = "test-utils"))]
+            has_fast_path: protocol.fast_path.is_some(),
             leaders: VecDeque::new(),
         }
     }
@@ -183,11 +189,23 @@ impl Committer {
             .expect("not a leader round");
         bc.wave.decision_round(bc.wave.number(leader_round))
     }
+
+    /// Shallowest DAG depth at which the direct rule can decide the leader at
+    /// `leader_round`: the voting round when a fast path is configured (votes
+    /// alone can commit), else the decision round.
+    /// Panics if `leader_round` is not a leader round.
+    pub fn earliest_decision_round_for(&self, leader_round: RoundNumber) -> RoundNumber {
+        if self.has_fast_path {
+            self.voting_round_for(leader_round)
+        } else {
+            self.decision_round_for(leader_round)
+        }
+    }
 }
 
 impl DagConsensus for Committer {
     fn quorum_threshold(&self) -> Stake {
-        self.direct_commit_quorum
+        self.quorum_threshold
     }
 
     fn try_commit(
@@ -207,5 +225,69 @@ impl DagConsensus for Committer {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use dag::{consensus::DagConsensus, storage::Storage, test_util::committee};
+
+    use crate::{
+        committer::Committer,
+        protocol::{FastPath, Protocol},
+    };
+
+    fn test_protocol(fast_path: Option<FastPath>) -> Protocol {
+        Protocol {
+            direct_commit_quorum: 3,
+            direct_skip_quorum: 3,
+            certificate_quorum: 3,
+            quorum_threshold: 4,
+            fast_path,
+            anchor_link_size: 1,
+            wave_length: 3,
+            leader_count: NonZeroUsize::new(1).unwrap(),
+            pipeline: false,
+            leader_wait: true,
+            require_crypto: false,
+        }
+    }
+
+    #[test]
+    fn quorum_threshold_sourced_from_protocol_field() {
+        let committee = committee(4);
+        let storage = Storage::new_for_test(&committee);
+        let committer = Committer::new(
+            committee.clone(),
+            storage.block_reader().clone(),
+            test_protocol(None),
+        );
+        assert_eq!(committer.quorum_threshold(), 4);
+    }
+
+    /// `earliest_decision_round_for` is the decision round for single-tier protocols
+    /// and the voting round when a fast path is configured.
+    #[test]
+    fn earliest_decision_round_tracks_fast_path() {
+        let committee = committee(4);
+        let storage = Storage::new_for_test(&committee);
+        let slow_committer = Committer::new(
+            committee.clone(),
+            storage.block_reader().clone(),
+            test_protocol(None),
+        );
+        let fast_committer = Committer::new(
+            committee.clone(),
+            storage.block_reader().clone(),
+            test_protocol(Some(FastPath {
+                commit_quorum: 3,
+                weak_indirect_quorum: 2,
+            })),
+        );
+        // Wave length 3: leader round 3 → voting round 4, decision round 5.
+        assert_eq!(slow_committer.earliest_decision_round_for(3), 5);
+        assert_eq!(fast_committer.earliest_decision_round_for(3), 4);
     }
 }

--- a/crates/consensus/src/protocol.rs
+++ b/crates/consensus/src/protocol.rs
@@ -236,12 +236,32 @@ pub enum ProtocolError {
     },
 }
 
+/// Optimistic fast-path parameters for dual-path protocols.
+#[derive(Clone, Copy)]
+pub struct FastPath {
+    /// The quorum of votes at the voting round to fast-commit a leader.
+    pub commit_quorum: Stake,
+    /// The quorum of anchor-linked votes to indirectly commit a leader
+    /// (second rung of the graded indirect rule).
+    pub weak_indirect_quorum: Stake,
+}
+
 /// Protocol-specific parameters for the consensus committer.
 pub struct Protocol {
-    /// The quorum threshold to directly commit a leader.
+    /// The quorum threshold to directly commit a leader: the number of
+    /// certificates required at the decision round (the outer threshold).
     pub direct_commit_quorum: Stake,
     /// The quorum threshold to directly skip a leader.
     pub direct_skip_quorum: Stake,
+    /// The quorum of votes a decision block must reference to count as a
+    /// certificate (the inner threshold).
+    pub certificate_quorum: Stake,
+    /// The quorum governing round advancement and block validity (parents /
+    /// availability). Historically implicit in `direct_commit_quorum`, with
+    /// which it coincides for all single-tier protocols.
+    pub quorum_threshold: Stake,
+    /// Optimistic fast-path parameters; `None` for single-tier protocols.
+    pub fast_path: Option<FastPath>,
     /// The stake of anchor-linked support required to indirectly decide a leader.
     pub anchor_link_size: Stake,
     /// The number of rounds to commit a leader.
@@ -266,6 +286,9 @@ impl Protocol {
         Self {
             direct_commit_quorum: quorum,
             direct_skip_quorum: total_stake,
+            certificate_quorum: quorum,
+            quorum_threshold: quorum,
+            fast_path: None,
             anchor_link_size: 1,
             wave_length: 3,
             leader_count: NonZeroUsize::new(1).unwrap(),
@@ -284,6 +307,9 @@ impl Protocol {
         Self {
             direct_commit_quorum: quorum,
             direct_skip_quorum: total_stake,
+            certificate_quorum: quorum,
+            quorum_threshold: quorum,
+            fast_path: None,
             anchor_link_size: 1,
             wave_length: 5,
             leader_count: NonZeroUsize::new(1).unwrap(),
@@ -302,6 +328,9 @@ impl Protocol {
         Self {
             direct_commit_quorum: quorum,
             direct_skip_quorum: quorum,
+            certificate_quorum: quorum,
+            quorum_threshold: quorum,
+            fast_path: None,
             anchor_link_size: 1,
             wave_length: 3,
             leader_count,
@@ -321,6 +350,9 @@ impl Protocol {
         Self {
             direct_commit_quorum: strong_quorum,
             direct_skip_quorum: strong_quorum,
+            certificate_quorum: strong_quorum,
+            quorum_threshold: strong_quorum,
+            fast_path: None,
             anchor_link_size: weak_quorum,
             wave_length: 2,
             leader_count,
@@ -352,6 +384,9 @@ impl Protocol {
         Ok(Self {
             direct_commit_quorum: total_stake - f - c,
             direct_skip_quorum: 4 * f + 2 * c + 1,
+            certificate_quorum: total_stake - f - c,
+            quorum_threshold: total_stake - f - c,
+            fast_path: None,
             anchor_link_size: total_stake - 3 * f - 2 * c,
             wave_length: 2,
             leader_count,
@@ -378,6 +413,9 @@ impl Protocol {
         Ok(Self {
             direct_commit_quorum: quorum,
             direct_skip_quorum: quorum,
+            certificate_quorum: quorum,
+            quorum_threshold: quorum,
+            fast_path: None,
             anchor_link_size: 1,
             wave_length,
             leader_count,
@@ -396,6 +434,9 @@ impl Protocol {
         Self {
             direct_commit_quorum: quorum,
             direct_skip_quorum: total_stake,
+            certificate_quorum: quorum,
+            quorum_threshold: quorum,
+            fast_path: None,
             anchor_link_size: 1,
             wave_length: 2,
             leader_count,

--- a/crates/consensus/tests/direct_commit_late_call_tests.rs
+++ b/crates/consensus/tests/direct_commit_late_call_tests.rs
@@ -39,7 +39,7 @@ fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
     let protocol = spec.to_protocol(committee).expect("valid protocol");
     let k = protocol.leader_count.get();
     let leader_rounds: Vec<_> = (1..=10).map(|n| committer.nth_leader_round(n)).collect();
-    let dag_depth = committer.decision_round_for(*leader_rounds.last().unwrap());
+    let dag_depth = committer.earliest_decision_round_for(*leader_rounds.last().unwrap());
     build_dag(committee, &mut storage, None, dag_depth);
 
     let sequence = committer.try_commit(None).collect::<Vec<_>>();

--- a/crates/consensus/tests/direct_commit_partial_round_tests.rs
+++ b/crates/consensus/tests/direct_commit_partial_round_tests.rs
@@ -46,8 +46,8 @@ fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
     let protocol = spec.to_protocol(committee).expect("valid protocol");
     let k = protocol.leader_count.get();
     let l1 = committer.nth_leader_round(1);
-    let decision_round = committer.decision_round_for(l1);
-    build_dag(committee, &mut storage, None, decision_round);
+    let earliest_decision = committer.earliest_decision_round_for(l1);
+    build_dag(committee, &mut storage, None, earliest_decision);
 
     let elector = LeaderElector::new(committee.len());
     let first_leader = elector.elect_leader(l1);

--- a/crates/consensus/tests/direct_commit_tests.rs
+++ b/crates/consensus/tests/direct_commit_tests.rs
@@ -39,8 +39,8 @@ fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
     let protocol = spec.to_protocol(committee).expect("valid protocol");
     let k = protocol.leader_count.get();
     let l1 = committer.nth_leader_round(1);
-    let decision_round = committer.decision_round_for(l1);
-    build_dag(committee, &mut storage, None, decision_round);
+    let earliest_decision = committer.earliest_decision_round_for(l1);
+    build_dag(committee, &mut storage, None, earliest_decision);
 
     let sequence = committer.try_commit(None).collect::<Vec<_>>();
     tracing::info!("[{spec}] Commit sequence: {sequence:?}");

--- a/crates/consensus/tests/direct_skip_tests.rs
+++ b/crates/consensus/tests/direct_skip_tests.rs
@@ -46,8 +46,8 @@ fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
 
         let l1_votes = build_dag(committee, &mut storage, None, l1);
         let l1_blames = drop_leader(&l1_votes, target_leader);
-        let decision_round = committer.decision_round_for(l1);
-        build_dag(committee, &mut storage, Some(l1_blames), decision_round);
+        let earliest_decision = committer.earliest_decision_round_for(l1);
+        build_dag(committee, &mut storage, Some(l1_blames), earliest_decision);
 
         let sequence = committer.try_commit(None).collect::<Vec<_>>();
         tracing::info!("[{spec}] target_offset={target_offset} sequence: {sequence:?}");

--- a/crates/consensus/tests/idempotence_tests.rs
+++ b/crates/consensus/tests/idempotence_tests.rs
@@ -38,7 +38,7 @@ fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
     let protocol = spec.to_protocol(committee).expect("valid protocol");
     let k = protocol.leader_count.get();
     let l2 = committer.nth_leader_round(2);
-    let dag_depth = committer.decision_round_for(l2);
+    let dag_depth = committer.earliest_decision_round_for(l2);
     build_dag(committee, &mut storage, None, dag_depth);
 
     let committed = committer.try_commit(None).collect::<Vec<_>>();

--- a/crates/consensus/tests/indirect_commit_tests.rs
+++ b/crates/consensus/tests/indirect_commit_tests.rs
@@ -8,10 +8,14 @@
 //!   `(direct_commit_quorum - 1)` voters and the rest non-voters. That's enough
 //!   for the later anchor to reach `anchor_link_size` certificate paths while
 //!   keeping direct commit below threshold.
-//! - `wl >= 3`: `build_split_chain` to the voting round with all
-//!   `direct_commit_quorum` authorities voting (final blamers = `n - direct_commit_quorum`),
+//! - `wl >= 3`: `build_split_chain` to the voting round with enough voters to
+//!   back a certificate (`certificate_quorum`, capped one below the fast-path
+//!   commit quorum so fast-path protocols stay undecided at the voting round),
 //!   then a hand-crafted decision-round layer where only
-//!   `(direct_commit_quorum - 1)` certifiers fully link to the voters.
+//!   `(direct_commit_quorum - 1)` certifiers fully link to the voters. When the
+//!   cap keeps the voters below `certificate_quorum`, no certificate forms and
+//!   the anchor decides the target through the weak indirect rung instead —
+//!   same assertion.
 //!
 //! For multi-leader cohorts, we sweep `target_offset` over `0..K`: the targeted
 //! cohort leader is the one driven into indirect-commit, while the remaining
@@ -76,7 +80,14 @@ fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
             );
             supports.into_iter().chain(blames).collect()
         } else {
-            let blamers_count = committee.len() - protocol.direct_commit_quorum as usize;
+            // Enough voters to back a certificate, capped one below the fast-path
+            // commit quorum: fast-path protocols must stay undecided at the voting
+            // round.
+            let voters_quorum = match &protocol.fast_path {
+                Some(fast_path) => protocol.certificate_quorum.min(fast_path.commit_quorum - 1),
+                None => protocol.certificate_quorum,
+            };
+            let blamers_count = committee.len() - voters_quorum as usize;
             let (supports, blames) = build_split_chain(
                 committee,
                 &mut storage,
@@ -97,7 +108,7 @@ fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
             let mixed_parents: Vec<_> = blames
                 .into_iter()
                 .chain(supports)
-                .take(protocol.direct_commit_quorum as usize)
+                .take(protocol.quorum_threshold as usize)
                 .collect();
             let non_certifier_connections = committee
                 .authorities()

--- a/crates/consensus/tests/indirect_commit_tests.rs
+++ b/crates/consensus/tests/indirect_commit_tests.rs
@@ -81,8 +81,11 @@ fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
             supports.into_iter().chain(blames).collect()
         } else {
             // Enough voters to back a certificate, capped one below the fast-path
-            // commit quorum: fast-path protocols must stay undecided at the voting
-            // round.
+            // commit quorum so fast-path protocols stay undecided at the voting
+            // round. When the cap wins (certificate quorum >= fast commit quorum),
+            // the voters intentionally fall below the certificate quorum: no
+            // certificate forms and the anchor commits the target through the
+            // weak indirect rung instead — same assertion.
             let voters_quorum = match &protocol.fast_path {
                 Some(fast_path) => {
                     let below_fast_commit = fast_path.commit_quorum.saturating_sub(1);

--- a/crates/consensus/tests/indirect_commit_tests.rs
+++ b/crates/consensus/tests/indirect_commit_tests.rs
@@ -84,7 +84,10 @@ fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
             // commit quorum: fast-path protocols must stay undecided at the voting
             // round.
             let voters_quorum = match &protocol.fast_path {
-                Some(fast_path) => protocol.certificate_quorum.min(fast_path.commit_quorum - 1),
+                Some(fast_path) => {
+                    let below_fast_commit = fast_path.commit_quorum.saturating_sub(1);
+                    protocol.certificate_quorum.min(below_fast_commit)
+                }
                 None => protocol.certificate_quorum,
             };
             let blamers_count = committee.len() - voters_quorum as usize;

--- a/crates/consensus/tests/indirect_skip_tests.rs
+++ b/crates/consensus/tests/indirect_skip_tests.rs
@@ -13,7 +13,10 @@
 //!   uniform-blamers construction would yield an indirect-*commit* instead.
 //! - **UniformBlamers** (everyone else): `build_split_chain` to the voting
 //!   round with `(direct_skip_quorum - 1)` blamers; the chain collapses to a
-//!   single layer when `wl <= 3`. The forward DAG is left full.
+//!   single layer when `wl <= 3`. The forward DAG is left full, except for
+//!   fast-path protocols whose residual supporters reach the weak indirect
+//!   quorum: there the supporter refs are excluded from the forward DAG (as in
+//!   HideVoters) so the anchor cannot weak-commit the target.
 
 use std::sync::Arc;
 
@@ -94,7 +97,19 @@ fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
                 committer.voting_round_for(target_round),
                 blamers_count,
             );
-            let forward_refs: Vec<_> = supports.into_iter().chain(blames).collect();
+            // With a fast path, the residual supporters can reach the weak indirect
+            // quorum, and an anchor that sees them would indirect-*commit* the target
+            // through the weak rung. Exclude them from the forward DAG in that case.
+            let residual_supporters = committee.len() as Stake - protocol.direct_skip_quorum + 1;
+            let hide_supporters = protocol
+                .fast_path
+                .as_ref()
+                .is_some_and(|fast_path| residual_supporters >= fast_path.weak_indirect_quorum);
+            let forward_refs: Vec<_> = if hide_supporters {
+                blames
+            } else {
+                supports.into_iter().chain(blames).collect()
+            };
             build_dag(committee, &mut storage, Some(forward_refs), anchor_decision);
         }
 

--- a/crates/consensus/tests/multiple_direct_commit_tests.rs
+++ b/crates/consensus/tests/multiple_direct_commit_tests.rs
@@ -46,7 +46,7 @@ fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
 
     for n in 1..=10 {
         let leader_round = template_committer.nth_leader_round(n);
-        let dag_depth = template_committer.decision_round_for(leader_round);
+        let dag_depth = template_committer.earliest_decision_round_for(leader_round);
 
         let mut storage = Storage::new_for_test(committee);
         build_dag(committee, &mut storage, None, dag_depth);

--- a/crates/consensus/tests/no_genesis_commit_tests.rs
+++ b/crates/consensus/tests/no_genesis_commit_tests.rs
@@ -36,9 +36,9 @@ fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
     let template_storage = Storage::new_for_test(committee);
     let template_committer = Committer::new_for_test(committee, &template_storage, spec);
     let l1 = template_committer.nth_leader_round(1);
-    let decision_round = template_committer.decision_round_for(l1);
+    let earliest_decision = template_committer.earliest_decision_round_for(l1);
 
-    for r in 0..decision_round {
+    for r in 0..earliest_decision {
         let mut storage = Storage::new_for_test(committee);
         build_dag(committee, &mut storage, None, r);
         let mut committer = Committer::new_for_test(committee, &storage, spec);

--- a/crates/consensus/tests/no_leader_tests.rs
+++ b/crates/consensus/tests/no_leader_tests.rs
@@ -52,7 +52,7 @@ fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
             .map(|a| (a, references_pre_leader.clone()))
             .collect();
         let references_at_leader = build_dag_layer(connections, &mut storage);
-        let decision = committer.decision_round_for(l1);
+        let decision = committer.earliest_decision_round_for(l1);
         build_dag(
             committee,
             &mut storage,

--- a/crates/consensus/tests/trailing_skip_not_re_yielded_tests.rs
+++ b/crates/consensus/tests/trailing_skip_not_re_yielded_tests.rs
@@ -48,7 +48,7 @@ fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
 
     let refs_at_leader = build_dag(committee, &mut storage, None, l1);
     let refs_without_target = drop_leader(&refs_at_leader, target_leader);
-    let decision = committer.decision_round_for(l1);
+    let decision = committer.earliest_decision_round_for(l1);
     build_dag(committee, &mut storage, Some(refs_without_target), decision);
 
     let first = committer.try_commit(None).collect::<Vec<_>>();


### PR DESCRIPTION
## Summary

Behavior-preserving refactor implementing #189 (part of epic #188): the minimal hooks the committer needs to express dual-path (optimistic fast-path) protocols such as DagHydrangea (#191) and RelaxedFinWhale (#190).

`direct_commit_quorum` did **triple** duty — one more than #189 recorded:

1. certificate **inner** threshold (`is_certificate`),
2. commit **outer** threshold (`enough_leader_support`),
3. the **pacemaker/parents quorum** via `Committer::quorum_threshold()`, feeding the dag threshold clock (`core.rs`) and received-block validity (`net_sync.rs`).

All three coincide for every shipped protocol but diverge for Hydrangea (`Q = 2f+c+k+1` vs `SLOW_ACKS = 2f+c+1` from `k ≥ 1`), so this PR splits all three into explicit `Protocol` fields: `certificate_quorum`, `quorum_threshold`, plus `fast_path: Option<FastPath { commit_quorum, weak_indirect_quorum }>` (bundled so the weak indirect rung cannot exist without the fast path that justifies it).

Three seams in `base.rs`, all inert while `fast_path` is `None`:
- `is_certificate` aggregates against `certificate_quorum`;
- `try_direct_decide` gains a fast-commit branch (`commit_quorum` votes at the voting round), short-circuiting on the `Option` before any storage access;
- `decide_leader_from_anchor` gains the graded rule's second rung (`weak_indirect_quorum` anchor-linked votes → lowest-digest deterministic pick), evaluated after the certificate rung and before `IndirectSkip`.

Scenario tests re-derive their DAG geometry from the semantically-correct field (`earliest_decision_round_for`, `certificate_quorum`, `quorum_threshold`) — identical geometry for all shipped protocols, and the matrix absorbs dual-path protocols in the follow-up without further changes.

## Behavior-preserving evidence

- Every constructor pins the new fields to its previous `direct_commit_quorum` value; new code paths are unreachable under `fast_path: None`.
- Full workspace test suite green; new unit tests pin both seam branches (fast commit at the voting round; weak-quorum indirect rung) against a `fast_path: None` control.
- `cargo check -p consensus` (default features) confirms the production build independent of test-utils feature unification.
- Audited by the refactor-guardian agent (verdict: bit-identical, no hot-path allocations or extra DAG traversals; the only addition on the direct path is one predicted branch per leader block) and a consensus-focused security review (no findings; latent recommendation for #191: validate `FastPath` quorum inequalities in the constructor, which the DagHydrangea parameters satisfy by design).

Closes #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)