### PR TITLE
docs: sync docs with the current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,11 @@
 # Mysticeti — uncertified DAG consensus
 
 Reference implementations of several uncertified DAG-based consensus protocols
-(Mysticeti, Mahi-Mahi, Blue Bottle, Cordial Miners PS/Async, Nemo-Nemo). The codebase is
-deliberately small and modular, meant for benchmarking and experimentation — **not
-production** — but uses real networking, cryptography, and persistent storage. Ships with
-a discrete-event simulator and a cloud orchestrator for running the protocols under custom
-scenarios.
+(Mysticeti, Mahi-Mahi, Blue Bottle, Orcaella, Cordial Miners PS/Async, Nemo-Nemo). The
+codebase is deliberately small and modular, meant for benchmarking and experimentation —
+**not production** — but uses real networking, cryptography, and persistent storage.
+Ships with a discrete-event simulator and a cloud orchestrator for running the protocols
+under custom scenarios.
 
 Rust **edition 2024**, toolchain pinned to **1.92** (see `rust-toolchain.toml`).
 
@@ -47,11 +47,12 @@ bypassing the hook.
 
 All supported protocols share one committer; they differ only in a flat parameter set
 (`Protocol`: `direct_commit_quorum`, `direct_skip_quorum`, `anchor_link_size`,
-`wave_length`, `leader_count`, `pipeline`, `leader_wait`). `ConsensusProtocol` is the
-user-facing enum that validates inputs and builds a `Protocol`. Rounds group into *waves*
-(leader round → voting round(s) → decision round); a leader is **directly** committed/
-skipped from votes/blames in its own wave, or **indirectly** decided later via an anchor.
-With `leader_count > 1` a round elects a *cohort* of K leaders (offsets `0..K`).
+`wave_length`, `leader_count`, `pipeline`, `leader_wait`, `require_crypto`).
+`ConsensusProtocol` is the user-facing enum that validates inputs and builds a `Protocol`.
+Rounds group into *waves* (leader round → voting round(s) → decision round); a leader is
+**directly** committed/skipped from votes/blames in its own wave, or **indirectly** decided
+later via an anchor. With `leader_count > 1` a round elects a *cohort* of K leaders
+(offsets `0..K`).
 
 ## Conventions
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,26 +166,29 @@ entry is:
 
 ```
 ┌──────┬────────┬─────┬──────────────┐
-│ crc32│ length │ tag │   payload    │
-│  u32 │  u64   │ u32 │  bincode     │
+│ crc  │ length │ tag │   payload    │
+│ u64  │  u32   │ u32 │  bincode     │
 └──────┴────────┴─────┴──────────────┘
 ```
 
-Three tag kinds cover everything the node persists: blocks (the canonical `Data<Block>` form that's
-also sent on the wire), payloads (the transaction batches produced by the load generator and pending
-inclusion in a future proposal), and commits (the `CommitData` emitted by the committer — leader
-plus ordered sub-DAG). No separate "metadata" store: the WAL is the only source of truth.
+(The checksum itself is a crc32, stored in a 64-bit slot.) Four tag kinds cover everything the node
+persists: incoming blocks (the canonical `Data<Block>` form that's also sent on the wire), the
+replica's own proposed blocks (written with their proposal metadata under a dedicated tag), payloads
+(the transaction batches produced by the load generator and pending inclusion in a future proposal),
+and commits (the `CommitData` emitted by the committer — leader plus ordered sub-DAG). A fifth,
+legacy state tag is skipped on replay and no longer written. No separate "metadata" store: the WAL
+is the only source of truth.
 
 Reads are zero-copy. The file is memory-mapped in 256 MB segments, and `BlockReader` hands out
 `minibytes::Bytes` slices that point directly into the mmap — no deserialization until something
 actually asks for a field.
 
 **Write path.** Only the `dag` thread ever writes. When a block arrives, the core's `add_blocks`
-path serializes it and appends a `WAL_ENTRY_BLOCK`. When the load generator hands in a fresh
-transaction batch, it becomes a `WAL_ENTRY_PAYLOAD` before the block handler holds on to its
-`WalPosition`. When the committer returns a decided leader, the surrounding sub-DAG is written as
-`WAL_ENTRY_COMMIT`. All three happen on the same thread, in the same loop iteration, so ordering is
-trivial.
+path serializes it and appends a `WAL_ENTRY_BLOCK`. When the core proposes its own block, it is
+written as a `WAL_ENTRY_OWN_BLOCK`. When the load generator hands in a fresh transaction batch, it
+becomes a `WAL_ENTRY_PAYLOAD` before the block handler holds on to its `WalPosition`. When the
+committer returns a decided leader, the surrounding sub-DAG is written as `WAL_ENTRY_COMMIT`. All of
+these happen on the same thread, in the same loop iteration, so ordering is trivial.
 
 **Durability.** A second dedicated OS thread — spawned with name `wal-syncer` by the `TokioCtx` —
 calls `wal_syncer.sync()` once per second
@@ -242,9 +245,9 @@ The two regimes correspond to the two families of protocols:
 
 - **Partially-synchronous / leader-waiting** — Mysticeti, Cordial Miners (partially synchronous).
   The committer's `get_leaders(round)` returns `Some(leaders)`. Before proposing at round `r+1`, the
-  core checks that **every expected leader** at round `r` has already published its block. If not,
-  the proposer waits up to the round timeout (default **1 s**) for the laggard before falling back
-  to `ForceNewBlock`.
+  core checks that **every connected expected leader** at round `r` has already published its
+  block. If not, the proposer waits up to the round timeout (default **1 s**) for the laggard
+  before falling back to `ForceNewBlock`.
 
 - **Asynchronous-friendly / quorum-waiting** — Cordial Miners (asynchronous), Mahi-Mahi.
   `get_leaders(round)` returns `None`. Before proposing, the core instead requires **every connected

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -5,8 +5,12 @@ and running benchmarks against the deployed network.
 
 The instructions below walk through a full run on [Amazon Web Services
 (AWS)](https://aws.amazon.com), which is the primary supported target. Additional cloud providers
-can be added by implementing the [`ServerProviderClient`](../crates/orchestrator/src/client/mod.rs)
+can be added by implementing the [`ServerProviderClient`](../crates/orchestrator/src/provider.rs)
 trait.
+
+All orchestrator functionality is driven through the `remote-testbed` subcommand of the `replica`
+binary; every invocation takes `--settings-path` pointing at the testbed settings file described
+below.
 
 ## 1. Cloud Provider Credentials
 
@@ -27,9 +31,8 @@ programmatically.
 
 ## 2. Testbed Configuration
 
-Create a `settings.yml` describing the testbed. The orchestrator reads this file (from
-`crates/orchestrator/assets/settings.yml` by default, or from any path passed via
-`--settings-path`). A minimal starting point, copied from
+Create a `settings.yml` describing the testbed and pass its path to every command via
+`--settings-path`. A minimal starting point, copied from
 [`assets/settings-aws-template.yml`](../crates/orchestrator/assets/settings-aws-template.yml)
 (see [`assets/settings-custom-template.yml`](../crates/orchestrator/assets/settings-custom-template.yml)
 for the custom, bring-your-own-machines provider):
@@ -71,26 +74,27 @@ repository:
 
 ## 3. Managing the Testbed
 
-The `testbed` subcommand group handles the lifecycle of cloud instances:
+The `remote-testbed` subcommands handle the lifecycle of cloud instances:
 
 ```bash
 # Create N instances in each region listed in settings.yml.
-cargo run --bin orchestrator -- testbed deploy --instances 2
+cargo run remote-testbed --settings-path settings.yml create --instances 2
 
-# Show the current state of all instances (green = up, red = stopped).
-cargo run --bin orchestrator -- testbed status
+# Show the current state of all instances (green = up, red = stopped)
+# and the SSH commands to reach them.
+cargo run remote-testbed --settings-path settings.yml status
 
 # Start up to N instances per region on an existing testbed.
-cargo run --bin orchestrator -- testbed start --instances 10
+cargo run remote-testbed --settings-path settings.yml start --instances 10
 
 # Stop all instances (preserves disks; start again to resume).
-cargo run --bin orchestrator -- testbed stop
+cargo run remote-testbed --settings-path settings.yml stop
 
 # Terminate all instances and release resources.
-cargo run --bin orchestrator -- testbed destroy
+cargo run remote-testbed --settings-path settings.yml destroy
 ```
 
-`deploy` also accepts `--region` to target a single region.
+`create` also accepts `--region` to target a single region.
 
 ## 4. Running Benchmarks
 
@@ -100,11 +104,12 @@ measurements by scraping the Prometheus metrics exposed on each node.
 
 ```bash
 # Benchmark a committee of 10 replicas under a 200 tx/s load.
-cargo run --bin orchestrator -- benchmark --committee 10 --loads 200
+cargo run remote-testbed --settings-path settings.yml benchmark --committee 10 --loads 200
 ```
 
-`--loads` accepts multiple values; the orchestrator runs one benchmark per load and saves each as
-its own measurements file under `results_dir` (default: `./results`). A load of `0` is special: the
+`--loads` accepts a comma-separated list (e.g. `--loads 100,200,300`); the orchestrator runs one
+benchmark per load and saves each as its own measurements file under `results_dir` (default:
+`./results`). A load of `0` is special: the
 orchestrator boots the replicas without any load generator, which is useful for testing with
 external clients.
 
@@ -149,14 +154,10 @@ the example at
 The scrape interval is controlled by `scrape_interval` (default 15s). If `log_processing: true`, the
 orchestrator also downloads per-instance log files to `logs_dir` after each run.
 
-## 7. Inspecting Past Results
+## 7. Inspecting Results
 
-Each benchmark saves a JSON measurements collection under `results_dir`. To re-print a summary for a
-saved run:
-
-```bash
-cargo run --bin orchestrator -- summarize --path ./results/measurements-...json
-```
-
-The summary reports TPS, average latency, and latency standard deviation per workload, together with
-the node count, fault configuration, offered load, and run duration.
+At the end of a run, the printed summary table reports each benchmark's name, node count, duration,
+consistency outcome, and committed-leader counts. The detailed performance data — every Prometheus
+sample collected during the run, including throughput rates and latency percentiles — is saved as a
+YAML measurements collection under `results_dir` (one `measurements-<parameters>.yaml` file per
+benchmark), keyed by metric name with the full label map of each sample for post-hoc filtering.

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -157,7 +157,7 @@ orchestrator also downloads per-instance log files to `logs_dir` after each run.
 ## 7. Inspecting Results
 
 At the end of a run, the printed summary table reports each benchmark's name, node count, duration,
-consistency outcome, and committed-leader counts. The detailed performance data — every Prometheus
-sample collected during the run, including throughput rates and latency percentiles — is saved as a
+and consistency outcome. The detailed performance data — every Prometheus sample collected during
+the run, including throughput rates and latency percentiles — is saved as a
 YAML measurements collection under `results_dir` (one `measurements-<parameters>.yaml` file per
 benchmark), keyed by metric name with the full label map of each sample for post-hoc filtering.

--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -53,7 +53,7 @@ All fields are optional and fall back to the defaults shown.
 | ----------------------------------- | ------------------------------------- | ----------- |
 | `name`                              | _(unset)_                             | Optional label shown in logs and the suite summary table. |
 | `committee_size`                    | `10`                                  | Number of replicas. Stake is uniform. |
-| `latency_min_ms` / `latency_max_ms` | `50` / `100`                          | Inclusive range for per-message link latency, sampled uniformly for every delivery. |
+| `latency_min_ms` / `latency_max_ms` | `50` / `100`                          | Range for per-message link latency (min inclusive, max exclusive), sampled uniformly for every delivery. |
 | `topology`                          | `fullMesh`                            | Network topology — see below. |
 | `duration_secs`                     | `20`                                  | Simulated time for which to run the simulation. |
 | `rng_seed`                          | `0`                                   | Seed for the deterministic RNG. Change this to get different per-run noise while keeping everything else fixed. |
@@ -109,7 +109,7 @@ leaves each file either intact or absent — never half-written.
 | `<output-dir>/tracing.log` | Suite-wide tracing log (one log for the whole invocation).                                                                                                |
 | `<run>/config.yaml`        | The full `SimulationConfig` that produced the run, including any defaults filled in.                                                                      |
 | `<run>/meta.yaml`          | `{ outcome, duration_secs, kind: simulation, timestamp_unix }`.                                                                                           |
-| `<run>/metrics.prom`       | Per-replica Prometheus text exposition; each replica's block is preceded by `# replica: N`. Parseable by `promtool`, Prometheus, and most TSDB ingesters. |
+| `<run>/metrics-<replica>.prom` | One Prometheus text exposition per replica (`metrics-A.prom`, `metrics-B.prom`, …), each self-contained and parseable by `promtool` and most TSDB ingesters. |
 | `<run>/dag.ndjson`         | _(opt-in via `--export-dag`)_ every committed sub-DAG, one JSON object per line. Can be many GB; off by default.                                          |
 
 ## Programmatic Use
@@ -119,11 +119,11 @@ The simulator is also usable as a library, which is how the integration tests in
 minimal example:
 
 ```rust
-use dag::metrics::Outcome;
+use replica::result::Outcome;
 use simulator::{NetworkTopology, SimulationConfig, SimulationRunner};
 
 #[test]
-fn one_down_still_commits() {
+fn one_down_stays_consistent() {
     let config = SimulationConfig {
         committee_size: 7,
         topology: NetworkTopology::OneDown(0),
@@ -133,14 +133,14 @@ fn one_down_still_commits() {
 
     let result = SimulationRunner::new(config).run().expect("simulation");
 
-    assert_eq!(result.outcome, Outcome::Pass);
-    assert!(result.commit_count_per_replica().iter().all(|&c| c > 0));
+    assert_ne!(result.outcome, Outcome::Diverged);
+    assert!(!result.metrics.is_empty());
 }
 ```
 
-`SimulationRunner::run` returns a `RunResult<SimulationConfig>` carrying per-replica
-`MetricsSnapshot`s, the derived `Outcome`, and the original config.
+`SimulationRunner::run` returns an `io::Result<RunResult<SimulationConfig>>` carrying per-replica
+`MetricsSnapshot`s, the derived `Outcome`, the per-replica storages, and the original config.
 `SimulationRunner::from_yaml` loads a `SimulationConfig` from disk, useful when test cases share
-configuration with the CLI. To stream every committed sub-DAG to disk during the run, chain
-`.with_dag_writer(writer)` on the runner before calling `run()`. Because every run is deterministic
-in the `rng_seed`, these tests are reproducible across machines.
+configuration with the CLI. The committed sub-DAGs stay available through the returned storages —
+that is how the CLI's `--export-dag` flag produces `dag.ndjson` after the run. Because every run is
+deterministic in the `rng_seed`, these tests are reproducible across machines.


### PR DESCRIPTION
## Summary

An audit of the markdown docs against the code found several claims that had drifted. This PR fixes everything stale relative to `main`:

- **CLAUDE.md**: add Orcaella to the protocol list; add `require_crypto` to the documented `Protocol` parameter set.
- **docs/architecture.md**: correct the WAL header field widths (crc is stored in a u64 slot, length is u32); document the `WAL_ENTRY_OWN_BLOCK` write and the legacy state tag (four active tag kinds, not three); note that leader-waiting only waits for *connected* expected leaders.
- **docs/simulator.md**: fix the Programmatic Use example — `Outcome` lives in `replica::result` (not `dag::metrics`), and `commit_count_per_replica()` / `.with_dag_writer()` don't exist; document the per-replica `metrics-<replica>.prom` files (there is no combined `metrics.prom`); mark the latency range max as exclusive.
- **docs/orchestrator.md**: rewrite the command examples around the `replica` binary's `remote-testbed` subcommand (there is no standalone `orchestrator` binary): `deploy` → `create`, required `--settings-path` (no default), no `summarize` command; fix the `ServerProviderClient` path (`src/provider.rs`); describe the YAML measurement files and the actual end-of-run summary contents; note `--loads` takes a comma-separated list.

The `fast-path-seams` branch adds further `Protocol` fields (`certificate_quorum`, `quorum_threshold`, `fast_path`); updating CLAUDE.md for those is left to that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)