### PR TITLE
feat(consensus): add DagHydrangea protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,11 @@
 # Mysticeti — uncertified DAG consensus
 
 Reference implementations of several uncertified DAG-based consensus protocols
-(Mysticeti, Mahi-Mahi, Blue Bottle, Orcaella, Cordial Miners PS/Async, Nemo-Nemo). The
-codebase is deliberately small and modular, meant for benchmarking and experimentation —
-**not production** — but uses real networking, cryptography, and persistent storage.
-Ships with a discrete-event simulator and a cloud orchestrator for running the protocols
-under custom scenarios.
+(Mysticeti, Mahi-Mahi, Blue Bottle, Orcaella, Cordial Miners PS/Async, Nemo-Nemo,
+DagHydrangea). The codebase is deliberately small and modular, meant for benchmarking and
+experimentation — **not production** — but uses real networking, cryptography, and
+persistent storage. Ships with a discrete-event simulator and a cloud orchestrator for
+running the protocols under custom scenarios.
 
 Rust **edition 2024**, toolchain pinned to **1.92** (see `rust-toolchain.toml`).
 
@@ -46,13 +46,16 @@ bypassing the hook.
 ## Consensus model (orientation)
 
 All supported protocols share one committer; they differ only in a flat parameter set
-(`Protocol`: `direct_commit_quorum`, `direct_skip_quorum`, `anchor_link_size`,
-`wave_length`, `leader_count`, `pipeline`, `leader_wait`, `require_crypto`).
-`ConsensusProtocol` is the user-facing enum that validates inputs and builds a `Protocol`.
-Rounds group into *waves* (leader round → voting round(s) → decision round); a leader is
-**directly** committed/skipped from votes/blames in its own wave, or **indirectly** decided
-later via an anchor. With `leader_count > 1` a round elects a *cohort* of K leaders
-(offsets `0..K`).
+(`Protocol`: `direct_commit_quorum`, `direct_skip_quorum`, `certificate_quorum`,
+`quorum_threshold`, `fast_path`, `anchor_link_size`, `wave_length`, `leader_count`,
+`pipeline`, `leader_wait`, `require_crypto`). `ConsensusProtocol` is the user-facing enum
+that validates inputs and builds a `Protocol`. Rounds group into *waves* (leader round →
+voting round(s) → decision round); a leader is **directly** committed/skipped from
+votes/blames in its own wave, or **indirectly** decided later via an anchor. With
+`leader_count > 1` a round elects a *cohort* of K leaders (offsets `0..K`). Dual-path
+protocols (DagHydrangea) set `fast_path: Some(..)`: a fast direct commit from votes at
+the voting round, reconciled with the certified slow path by a graded indirect rule
+(certificate → weak quorum → skip).
 
 ## Conventions
 

--- a/crates/consensus/src/protocol.rs
+++ b/crates/consensus/src/protocol.rs
@@ -582,34 +582,39 @@ impl Protocol {
         k: Stake,
         leader_count: NonZeroUsize,
     ) -> Result<Self, ProtocolError> {
+        // Widen to u128 so the bound and threshold arithmetic cannot overflow;
+        // every resulting threshold is at most `total_stake`, so narrowing back
+        // to `Stake` is safe.
+        let n = total_stake as u128;
+        let (f, c, k) = (f as u128, c as u128, k as u128);
         let min_n = 3 * f + 2 * c + k + 1;
-        if min_n > total_stake {
+        if min_n > n {
             return Err(ProtocolError::FaultBoundViolated {
                 protocol: "DagHydrangea",
                 n: total_stake,
-                min_n,
+                min_n: Stake::try_from(min_n).unwrap_or(Stake::MAX),
             });
         }
 
         let p = (c + k) / 2;
         // ceil((n + f + 1) / 2): large enough that two conflicting certificates
         // cannot both form.
-        let certificate_quorum = (total_stake + f + 2) / 2;
+        let certificate_quorum = (n + f + 2) / 2;
         let fast_path = FastPath {
-            commit_quorum: total_stake - p,
-            weak_indirect_quorum: f + p + 1,
+            commit_quorum: (n - p) as Stake,
+            weak_indirect_quorum: (f + p + 1) as Stake,
         };
         // Certificate uniqueness, and a fast commit starving every conflicting
         // leader block below the weak indirect quorum. Both follow from the fault
         // bound; assert to catch arithmetic regressions.
-        assert!(2 * certificate_quorum > total_stake + f);
-        assert!(fast_path.commit_quorum + fast_path.weak_indirect_quorum > total_stake + f);
+        assert!(2 * certificate_quorum > n + f);
+        assert!((n - p) + (f + p + 1) > n + f);
 
         Ok(Self {
-            direct_commit_quorum: 2 * f + c + 1,
+            direct_commit_quorum: (2 * f + c + 1) as Stake,
             direct_skip_quorum: fast_path.commit_quorum,
-            certificate_quorum,
-            quorum_threshold: total_stake - f - c,
+            certificate_quorum: certificate_quorum as Stake,
+            quorum_threshold: (n - f - c) as Stake,
             fast_path: Some(fast_path),
             anchor_link_size: 1,
             wave_length: 3,

--- a/crates/consensus/src/protocol.rs
+++ b/crates/consensus/src/protocol.rs
@@ -606,9 +606,11 @@ impl Protocol {
         };
         // Certificate uniqueness, and a fast commit starving every conflicting
         // leader block below the weak indirect quorum. Both follow from the fault
-        // bound; assert to catch arithmetic regressions.
+        // bound; assert on the stored thresholds to catch formula regressions.
         assert!(2 * certificate_quorum > n + f);
-        assert!((n - p) + (f + p + 1) > n + f);
+        let fast_commit_quorum = fast_path.commit_quorum as u128;
+        let weak_indirect_quorum = fast_path.weak_indirect_quorum as u128;
+        assert!(fast_commit_quorum + weak_indirect_quorum > n + f);
 
         Ok(Self {
             direct_commit_quorum: (2 * f + c + 1) as Stake,

--- a/crates/consensus/src/protocol.rs
+++ b/crates/consensus/src/protocol.rs
@@ -46,6 +46,16 @@ pub enum ConsensusProtocol {
         #[serde(default = "defaults::default_leader_count")]
         leader_count: NonZeroUsize,
     },
+    DagHydrangea {
+        #[serde(default = "defaults::default_leader_count")]
+        leader_count: NonZeroUsize,
+        /// Byzantine-fault stake to tolerate.
+        f: Stake,
+        /// Crash-only fault stake to tolerate (on top of `f`).
+        c: Stake,
+        /// Tunable slack widening the fast path; requires `n >= 3f + 2c + k + 1`.
+        k: Stake,
+    },
 }
 
 mod defaults {
@@ -110,6 +120,18 @@ impl fmt::Display for ConsensusProtocol {
             Self::NemoNemo { leader_count } => {
                 write!(fmt, "Nemo-Nemo ({} leaders/round)", leader_count)
             }
+            Self::DagHydrangea {
+                leader_count,
+                f,
+                c,
+                k,
+            } => {
+                write!(
+                    fmt,
+                    "DagHydrangea ({} leaders/round, f={f}, c={c}, k={k})",
+                    leader_count
+                )
+            }
         }
     }
 }
@@ -131,6 +153,12 @@ impl fmt::Debug for ConsensusProtocol {
                 wave_length,
             } => write!(fmt, "mahi-mahi-l{leader_count}-w{wave_length}"),
             Self::NemoNemo { leader_count } => write!(fmt, "nemo-nemo-l{leader_count}"),
+            Self::DagHydrangea {
+                leader_count,
+                f,
+                c,
+                k,
+            } => write!(fmt, "dag-hydrangea-l{leader_count}-f{f}-c{c}-k{k}"),
         }
     }
 }
@@ -146,7 +174,8 @@ impl ConsensusProtocol {
             | Self::BlueBottle { leader_count }
             | Self::Orcaella { leader_count, .. }
             | Self::MahiMahi { leader_count, .. }
-            | Self::NemoNemo { leader_count } => Some(*leader_count),
+            | Self::NemoNemo { leader_count }
+            | Self::DagHydrangea { leader_count, .. } => Some(*leader_count),
         };
         if let Some(leader_count) = user_leader_count
             && leader_count.get() > committee_size
@@ -172,6 +201,12 @@ impl ConsensusProtocol {
                 wave_length,
             } => Protocol::mahi_mahi(total_stake, leader_count, wave_length)?,
             Self::NemoNemo { leader_count } => Protocol::nemo_nemo(total_stake, leader_count),
+            Self::DagHydrangea {
+                leader_count,
+                f,
+                c,
+                k,
+            } => Protocol::dag_hydrangea(total_stake, f, c, k, leader_count)?,
         })
     }
 }
@@ -215,9 +250,95 @@ impl ConsensusProtocol {
                 leader_count,
                 wave_length: 5,
             });
+            variants.push(Self::DagHydrangea {
+                leader_count,
+                f: 1,
+                c: 0,
+                k: 0,
+            });
+            variants.push(Self::DagHydrangea {
+                leader_count,
+                f: 0,
+                c: 1,
+                k: 1,
+            });
+            if n >= 20 {
+                variants.push(Self::DagHydrangea {
+                    leader_count,
+                    f: 6,
+                    c: 0,
+                    k: 1,
+                });
+                variants.push(Self::DagHydrangea {
+                    leader_count,
+                    f: 0,
+                    c: 9,
+                    k: 1,
+                });
+                variants.push(Self::DagHydrangea {
+                    leader_count,
+                    f: 3,
+                    c: 4,
+                    k: 2,
+                });
+                variants.push(Self::DagHydrangea {
+                    leader_count,
+                    f: 4,
+                    c: 1,
+                    k: 5,
+                });
+            }
         }
         variants.push(Self::CordialMinersPartiallySynchronous);
         variants.push(Self::CordialMinersAsynchronous);
+        variants
+    }
+
+    /// Fast-path protocols at the baseline matrix configuration, for the
+    /// fast-path-specific scenario tests.
+    pub fn all_fast_path_for_test(n: usize, leader_counts: &[usize]) -> Vec<Self> {
+        let mut variants = Vec::new();
+        for &l in leader_counts {
+            let leader_count = NonZeroUsize::new(l).expect("leader_count must be non-zero");
+            variants.push(Self::DagHydrangea {
+                leader_count,
+                f: 1,
+                c: 0,
+                k: 0,
+            });
+            variants.push(Self::DagHydrangea {
+                leader_count,
+                f: 0,
+                c: 1,
+                k: 1,
+            });
+            if n >= 20 {
+                variants.push(Self::DagHydrangea {
+                    leader_count,
+                    f: 6,
+                    c: 0,
+                    k: 1,
+                });
+                variants.push(Self::DagHydrangea {
+                    leader_count,
+                    f: 0,
+                    c: 9,
+                    k: 1,
+                });
+                variants.push(Self::DagHydrangea {
+                    leader_count,
+                    f: 3,
+                    c: 4,
+                    k: 2,
+                });
+                variants.push(Self::DagHydrangea {
+                    leader_count,
+                    f: 4,
+                    c: 1,
+                    k: 5,
+                });
+            }
+        }
         variants
     }
 }
@@ -225,8 +346,12 @@ impl ConsensusProtocol {
 /// Errors that can arise when building a [`Protocol`] from a [`ConsensusProtocol`].
 #[derive(Debug, thiserror::Error)]
 pub enum ProtocolError {
-    #[error("Orcaella fault bound violated (n={n}, f={f}, c={c})")]
-    OrcaellaFaultBoundViolated { n: Stake, f: Stake, c: Stake },
+    #[error("{protocol} fault bound violated: requires n >= {min_n}, got n = {n}")]
+    FaultBoundViolated {
+        protocol: &'static str,
+        n: Stake,
+        min_n: Stake,
+    },
     #[error("Mahi-Mahi requires wave_length in {{4, 5}}, got {wave_length}")]
     MahiMahiInvalidWaveLength { wave_length: RoundNumber },
     #[error("leader_count ({leader_count}) exceeds committee size ({committee_size})")]
@@ -374,10 +499,10 @@ impl Protocol {
     ) -> Result<Self, ProtocolError> {
         let min_n = if f == 0 { 2 * c + 1 } else { 5 * f + 3 * c + 1 };
         if min_n > total_stake {
-            return Err(ProtocolError::OrcaellaFaultBoundViolated {
+            return Err(ProtocolError::FaultBoundViolated {
+                protocol: "Orcaella",
                 n: total_stake,
-                f,
-                c,
+                min_n,
             });
         }
 
@@ -445,6 +570,55 @@ impl Protocol {
             require_crypto: false,
         }
     }
+
+    /// DagHydrangea
+    ///
+    /// "Hydrangea: Optimistic Two-Round Partial Synchrony with Improved Fault Resilience"
+    /// <https://eprint.iacr.org/2025/1112>
+    pub fn dag_hydrangea(
+        total_stake: Stake,
+        f: Stake,
+        c: Stake,
+        k: Stake,
+        leader_count: NonZeroUsize,
+    ) -> Result<Self, ProtocolError> {
+        let min_n = 3 * f + 2 * c + k + 1;
+        if min_n > total_stake {
+            return Err(ProtocolError::FaultBoundViolated {
+                protocol: "DagHydrangea",
+                n: total_stake,
+                min_n,
+            });
+        }
+
+        let p = (c + k) / 2;
+        // ceil((n + f + 1) / 2): large enough that two conflicting certificates
+        // cannot both form.
+        let certificate_quorum = (total_stake + f + 2) / 2;
+        let fast_path = FastPath {
+            commit_quorum: total_stake - p,
+            weak_indirect_quorum: f + p + 1,
+        };
+        // Certificate uniqueness, and a fast commit starving every conflicting
+        // leader block below the weak indirect quorum. Both follow from the fault
+        // bound; assert to catch arithmetic regressions.
+        assert!(2 * certificate_quorum > total_stake + f);
+        assert!(fast_path.commit_quorum + fast_path.weak_indirect_quorum > total_stake + f);
+
+        Ok(Self {
+            direct_commit_quorum: 2 * f + c + 1,
+            direct_skip_quorum: fast_path.commit_quorum,
+            certificate_quorum,
+            quorum_threshold: total_stake - f - c,
+            fast_path: Some(fast_path),
+            anchor_link_size: 1,
+            wave_length: 3,
+            leader_count,
+            pipeline: true,
+            leader_wait: true,
+            require_crypto: f != 0,
+        })
+    }
 }
 
 impl Protocol {
@@ -457,5 +631,52 @@ impl Protocol {
         } else {
             Duration::from_millis(75)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use crate::protocol::{Protocol, ProtocolError};
+
+    /// Reference thresholds from the design note at the mixed configuration
+    /// n = 20, f = 3, c = 4, k = 2 (p = 3), where the certificate, slow-commit,
+    /// and pacemaker quorums are all distinct.
+    #[test]
+    fn dag_hydrangea_thresholds_mixed_configuration() {
+        let protocol = Protocol::dag_hydrangea(20, 3, 4, 2, NonZeroUsize::new(1).unwrap()).unwrap();
+        let fast_path = protocol.fast_path.expect("dual-path protocol");
+        assert_eq!(fast_path.commit_quorum, 17); // n - p
+        assert_eq!(fast_path.weak_indirect_quorum, 7); // f + p + 1
+        assert_eq!(protocol.certificate_quorum, 12); // ceil((n + f + 1) / 2)
+        assert_eq!(protocol.direct_commit_quorum, 11); // 2f + c + 1
+        assert_eq!(protocol.direct_skip_quorum, 17); // n - p
+        assert_eq!(protocol.quorum_threshold, 13); // n - f - c
+    }
+
+    /// At `k = 0` the certificate, slow-commit, and pacemaker quorums coincide
+    /// (n = 99, f = 10, c = 34 from the design note).
+    #[test]
+    fn dag_hydrangea_quorums_coincide_at_zero_slack() {
+        let protocol =
+            Protocol::dag_hydrangea(99, 10, 34, 0, NonZeroUsize::new(1).unwrap()).unwrap();
+        assert_eq!(protocol.certificate_quorum, 55);
+        assert_eq!(protocol.direct_commit_quorum, 55);
+        assert_eq!(protocol.quorum_threshold, 55);
+    }
+
+    /// The fault bound `n >= 3f + 2c + k + 1` is enforced.
+    #[test]
+    fn dag_hydrangea_fault_bound_rejected() {
+        let result = Protocol::dag_hydrangea(4, 1, 0, 1, NonZeroUsize::new(1).unwrap());
+        assert!(matches!(
+            result,
+            Err(ProtocolError::FaultBoundViolated {
+                protocol: "DagHydrangea",
+                n: 4,
+                min_n: 5,
+            })
+        ));
     }
 }

--- a/crates/consensus/tests/equivocation_certificate_beats_weak_quorum_tests.rs
+++ b/crates/consensus/tests/equivocation_certificate_beats_weak_quorum_tests.rs
@@ -1,0 +1,194 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `equivocation_certificate_beats_weak_quorum` scenario across the fast-path
+//! protocol matrix.
+//!
+//! An equivocating target leader produces two blocks: B1 gathers exactly
+//! `certificate_quorum` votes and `direct_commit_quorum - 1` certificates (one
+//! short of a slow commit, so the direct rule stays undecided), while B2
+//! gathers exactly `weak_indirect_quorum` votes. The anchor links everything,
+//! so both rungs of the graded indirect rule have a qualifier — the test pins
+//! that the certificate rung is evaluated first and B1 wins, even though B2
+//! clears the weak quorum.
+//!
+//! Requires disjoint voter sets (`certificate_quorum + weak_indirect_quorum
+//! <= n`), which also guarantees the B1 votes stay below the fast quorum;
+//! configurations violating it are skipped (quorum intersection makes the two
+//! footprints mutually exclusive there — a protocol property, not a test gap).
+
+use std::sync::Arc;
+
+use consensus::{committer::Committer, leader::LeaderElector, protocol::ConsensusProtocol};
+use dag::{
+    authority::Authority,
+    block::Block,
+    committee::Committee,
+    consensus::LeaderStatus,
+    crypto::{BLOCK_DIGEST_SIZE, BlockDigest},
+    storage::Storage,
+    test_util::{build_dag, build_dag_layer, committee, insert_test_block},
+};
+
+#[test]
+#[tracing_test::traced_test]
+fn equivocation_certificate_beats_weak_quorum_n4() {
+    run_for_size(4);
+}
+
+#[test]
+#[tracing_test::traced_test]
+fn equivocation_certificate_beats_weak_quorum_n20() {
+    run_for_size(20);
+}
+
+fn run_for_size(n: usize) {
+    let committee = committee(n);
+    let leader_counts = [1, 2, 2 * n / 3 + 1, n];
+    for spec in ConsensusProtocol::all_fast_path_for_test(n, &leader_counts) {
+        run(&spec, &committee);
+    }
+}
+
+fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
+    let protocol = spec.to_protocol(committee).expect("valid protocol");
+    let fast_path = protocol.fast_path.expect("fast-path protocol");
+    let b1_voters = protocol.certificate_quorum as usize;
+    let b2_voters = fast_path.weak_indirect_quorum as usize;
+    if b1_voters + b2_voters > committee.len() {
+        return;
+    }
+    let k = protocol.leader_count.get();
+    let elector = LeaderElector::new(committee.len());
+
+    for target_offset in 0..k {
+        let mut storage = Storage::new_for_test(committee);
+        let mut committer = Committer::new_for_test(committee, &storage, spec);
+        let l1 = committer.nth_leader_round(1);
+        let decision_round = committer.decision_round_for(l1);
+        let target_leader = elector.elect_leader(l1 + target_offset as u64);
+        if target_leader == Authority::default() {
+            // The block store enforces that its own authority never equivocates
+            // (one own block per round); observe equivocation from a peer, as a
+            // correct replica would.
+            continue;
+        }
+
+        let references_pre_leader = build_dag(committee, &mut storage, None, l1 - 1);
+
+        // Leader layer: the target equivocates. B1 is its regular proposal; B2
+        // carries a distinct digest (the synthetic test digest is keyed by round
+        // and authority alone, so same-slot blocks would otherwise collapse into
+        // one reference). Every other authority proposes normally.
+        let leader_connections = committee
+            .authorities()
+            .map(|authority| (authority, references_pre_leader.clone()))
+            .collect();
+        let leader_refs = build_dag_layer(leader_connections, &mut storage);
+        let b1_ref = *leader_refs
+            .iter()
+            .find(|reference| reference.authority == target_leader)
+            .expect("target proposed in the leader layer");
+        let honest_refs: Vec<_> = leader_refs
+            .iter()
+            .copied()
+            .filter(|reference| reference.authority != target_leader)
+            .collect();
+        let mut b2_digest = [0u8; BLOCK_DIGEST_SIZE];
+        b2_digest[BLOCK_DIGEST_SIZE - 1] = 1;
+        let b2_ref = insert_test_block(
+            Block::new_for_test(target_leader, l1, references_pre_leader.clone())
+                .with_digest(BlockDigest::from(b2_digest)),
+            &mut storage,
+        );
+
+        // Voting layer: `certificate_quorum` authorities vote B1,
+        // `weak_indirect_quorum` vote B2, the rest blame the target slot.
+        let voting_connections = committee
+            .authorities()
+            .enumerate()
+            .map(|(i, authority)| {
+                let mut parents = honest_refs.clone();
+                if i < b1_voters {
+                    parents.push(b1_ref);
+                } else if i < b1_voters + b2_voters {
+                    parents.push(b2_ref);
+                }
+                (authority, parents)
+            })
+            .collect();
+        let voting_refs = build_dag_layer(voting_connections, &mut storage);
+        let b1_vote_refs: Vec<_> = voting_refs[..b1_voters].to_vec();
+        let other_vote_refs: Vec<_> = voting_refs[b1_voters..].to_vec();
+
+        // Decision layer: `direct_commit_quorum - 1` certifiers link every B1
+        // vote (each is a certificate for B1, one short of a slow commit); the
+        // rest link the B2 votes and blames (below the certificate quorum, so
+        // B2 is never certified and certificate uniqueness holds).
+        let certifiers_count = (protocol.direct_commit_quorum - 1) as usize;
+        let decision_connections = committee
+            .authorities()
+            .enumerate()
+            .map(|(i, authority)| {
+                let parents = if i < certifiers_count {
+                    b1_vote_refs.clone()
+                } else {
+                    other_vote_refs.clone()
+                };
+                (authority, parents)
+            })
+            .collect();
+        let decision_refs = build_dag_layer(decision_connections, &mut storage);
+
+        // Forward DAG: the anchor commits and links both footprints.
+        let anchor_round = committer.next_leader_round_after(decision_round);
+        let anchor_decision = committer.decision_round_for(anchor_round);
+        build_dag(
+            committee,
+            &mut storage,
+            Some(decision_refs),
+            anchor_decision,
+        );
+
+        let sequence = committer.try_commit(None).collect::<Vec<_>>();
+        tracing::info!("[{spec}] target_offset={target_offset} sequence: {sequence:?}");
+
+        assert!(
+            sequence.len() >= k,
+            "[{spec}] target_offset={target_offset} expected at least {k} decisions"
+        );
+        for (offset, decision) in sequence.iter().take(k).enumerate() {
+            let expected = elector.elect_leader(l1 + offset as u64);
+            if offset == target_offset {
+                match decision {
+                    LeaderStatus::IndirectCommit(block) => {
+                        assert_eq!(
+                            *block.reference(),
+                            b1_ref,
+                            "[{spec}] target_offset={target_offset} expected the certified \
+                            B1, not the weak-quorum B2 ({b2_ref:?})"
+                        );
+                    }
+                    other => panic!(
+                        "[{spec}] target_offset={target_offset} expected IndirectCommit at \
+                        offset {offset}, got {other:?}"
+                    ),
+                }
+            } else {
+                match decision {
+                    LeaderStatus::DirectCommit(block) => {
+                        assert_eq!(
+                            block.author(),
+                            expected,
+                            "[{spec}] target_offset={target_offset} offset={offset}"
+                        );
+                    }
+                    other => panic!(
+                        "[{spec}] target_offset={target_offset} expected DirectCommit at \
+                        offset {offset}, got {other:?}"
+                    ),
+                }
+            }
+        }
+    }
+}

--- a/crates/consensus/tests/fast_commit_tests.rs
+++ b/crates/consensus/tests/fast_commit_tests.rs
@@ -1,0 +1,100 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `fast_commit` scenario across the fast-path protocol matrix.
+//!
+//! Builds votes at the voting round and nothing above it: the decision round
+//! is absent, so no certificate can exist and a commit can only come from the
+//! fast path. The target leader receives exactly `fast_path.commit_quorum`
+//! votes (the boundary), the remaining authorities blame it; sibling cohort
+//! leaders receive every vote.
+
+use std::sync::Arc;
+
+use consensus::{committer::Committer, leader::LeaderElector, protocol::ConsensusProtocol};
+use dag::{
+    committee::Committee,
+    consensus::LeaderStatus,
+    storage::Storage,
+    test_util::{build_dag, build_dag_layer, committee, drop_leader},
+};
+
+#[test]
+#[tracing_test::traced_test]
+fn fast_commit_n4() {
+    run_for_size(4);
+}
+
+#[test]
+#[tracing_test::traced_test]
+fn fast_commit_n20() {
+    run_for_size(20);
+}
+
+fn run_for_size(n: usize) {
+    let committee = committee(n);
+    let leader_counts = [1, 2, 2 * n / 3 + 1, n];
+    for spec in ConsensusProtocol::all_fast_path_for_test(n, &leader_counts) {
+        run(&spec, &committee);
+    }
+}
+
+fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
+    let protocol = spec.to_protocol(committee).expect("valid protocol");
+    let fast_path = protocol.fast_path.expect("fast-path protocol");
+    let k = protocol.leader_count.get();
+    let elector = LeaderElector::new(committee.len());
+
+    for target_offset in 0..k {
+        let mut storage = Storage::new_for_test(committee);
+        let mut committer = Committer::new_for_test(committee, &storage, spec);
+        let l1 = committer.nth_leader_round(1);
+        let target_leader = elector.elect_leader(l1 + target_offset as u64);
+
+        let l1_votes = build_dag(committee, &mut storage, None, l1);
+        let l1_blames = drop_leader(&l1_votes, target_leader);
+
+        // Voting layer only: the first `commit_quorum` authorities vote for the
+        // target, the rest blame it. No decision round exists, so the fast path
+        // is the only way to commit.
+        let voters_count = fast_path.commit_quorum as usize;
+        let connections = committee
+            .authorities()
+            .enumerate()
+            .map(|(i, authority)| {
+                let parents = if i < voters_count {
+                    l1_votes.clone()
+                } else {
+                    l1_blames.clone()
+                };
+                (authority, parents)
+            })
+            .collect();
+        build_dag_layer(connections, &mut storage);
+
+        let sequence = committer.try_commit(None).collect::<Vec<_>>();
+        tracing::info!("[{spec}] target_offset={target_offset} sequence: {sequence:?}");
+
+        assert_eq!(
+            sequence.len(),
+            k,
+            "[{spec}] target_offset={target_offset} expected {k} decisions"
+        );
+        for (offset, decision) in sequence.iter().enumerate() {
+            let expected = elector.elect_leader(l1 + offset as u64);
+            match decision {
+                LeaderStatus::DirectCommit(block) => {
+                    assert_eq!(
+                        block.author(),
+                        expected,
+                        "[{spec}] target_offset={target_offset} offset={offset}"
+                    );
+                }
+                other => panic!(
+                    "[{spec}] target_offset={target_offset} expected DirectCommit at \
+                    offset {offset}, got {other:?}"
+                ),
+            }
+        }
+    }
+}

--- a/crates/consensus/tests/fast_missed_slow_commit_tests.rs
+++ b/crates/consensus/tests/fast_missed_slow_commit_tests.rs
@@ -1,0 +1,108 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `fast_missed_slow_commit` scenario across the fast-path protocol matrix.
+//!
+//! The target leader misses the fast path by one vote (`commit_quorum - 1`
+//! voters, the rest blame), but a fully-connected decision round turns every
+//! decision block into a certificate: the slow path commits the target
+//! directly. Skipped for configurations where the certificate quorum reaches
+//! the fast commit quorum: there any certificate implies a fast commit, so
+//! the slow path is unreachable by construction (a protocol property, not a
+//! test gap).
+
+use std::sync::Arc;
+
+use consensus::{committer::Committer, leader::LeaderElector, protocol::ConsensusProtocol};
+use dag::{
+    committee::Committee,
+    consensus::LeaderStatus,
+    storage::Storage,
+    test_util::{build_dag, build_dag_layer, committee, drop_leader},
+};
+
+#[test]
+#[tracing_test::traced_test]
+fn fast_missed_slow_commit_n4() {
+    run_for_size(4);
+}
+
+#[test]
+#[tracing_test::traced_test]
+fn fast_missed_slow_commit_n20() {
+    run_for_size(20);
+}
+
+fn run_for_size(n: usize) {
+    let committee = committee(n);
+    let leader_counts = [1, 2, 2 * n / 3 + 1, n];
+    for spec in ConsensusProtocol::all_fast_path_for_test(n, &leader_counts) {
+        run(&spec, &committee);
+    }
+}
+
+fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
+    let protocol = spec.to_protocol(committee).expect("valid protocol");
+    let fast_path = protocol.fast_path.expect("fast-path protocol");
+    if protocol.certificate_quorum >= fast_path.commit_quorum {
+        return;
+    }
+    let k = protocol.leader_count.get();
+    let elector = LeaderElector::new(committee.len());
+
+    for target_offset in 0..k {
+        let mut storage = Storage::new_for_test(committee);
+        let mut committer = Committer::new_for_test(committee, &storage, spec);
+        let l1 = committer.nth_leader_round(1);
+        let decision_round = committer.decision_round_for(l1);
+        let target_leader = elector.elect_leader(l1 + target_offset as u64);
+
+        let l1_votes = build_dag(committee, &mut storage, None, l1);
+        let l1_blames = drop_leader(&l1_votes, target_leader);
+
+        // Voting layer: one vote short of the fast path; the certificate quorum
+        // is still met (gated above).
+        let voters_count = (fast_path.commit_quorum - 1) as usize;
+        let connections = committee
+            .authorities()
+            .enumerate()
+            .map(|(i, authority)| {
+                let parents = if i < voters_count {
+                    l1_votes.clone()
+                } else {
+                    l1_blames.clone()
+                };
+                (authority, parents)
+            })
+            .collect();
+        let voting_refs = build_dag_layer(connections, &mut storage);
+
+        // Fully-connected decision round: every decision block references all
+        // voters, so each is a certificate and the slow path commits.
+        build_dag(committee, &mut storage, Some(voting_refs), decision_round);
+
+        let sequence = committer.try_commit(None).collect::<Vec<_>>();
+        tracing::info!("[{spec}] target_offset={target_offset} sequence: {sequence:?}");
+
+        assert!(
+            sequence.len() >= k,
+            "[{spec}] target_offset={target_offset} expected at least {k} decisions"
+        );
+        for (offset, decision) in sequence.iter().take(k).enumerate() {
+            let expected = elector.elect_leader(l1 + offset as u64);
+            match decision {
+                LeaderStatus::DirectCommit(block) => {
+                    assert_eq!(
+                        block.author(),
+                        expected,
+                        "[{spec}] target_offset={target_offset} offset={offset}"
+                    );
+                }
+                other => panic!(
+                    "[{spec}] target_offset={target_offset} expected DirectCommit at \
+                    offset {offset}, got {other:?}"
+                ),
+            }
+        }
+    }
+}

--- a/crates/consensus/tests/fast_missed_weak_indirect_commit_tests.rs
+++ b/crates/consensus/tests/fast_missed_weak_indirect_commit_tests.rs
@@ -1,0 +1,124 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `fast_missed_weak_indirect_commit` scenario across the fast-path protocol
+//! matrix.
+//!
+//! The target leader receives exactly `weak_indirect_quorum` votes: too few
+//! for the fast path, too few for any certificate (the weak quorum is always
+//! below both), and the blames stay below the skip quorum — the direct rule
+//! leaves the target undecided. The forward DAG commits a later anchor that
+//! links every vote, so the graded indirect rule finds no certificate (rung 1)
+//! but a weak quorum of anchor-linked votes (rung 2) and indirect-commits the
+//! target.
+
+use std::sync::Arc;
+
+use consensus::{committer::Committer, leader::LeaderElector, protocol::ConsensusProtocol};
+use dag::{
+    committee::Committee,
+    consensus::LeaderStatus,
+    storage::Storage,
+    test_util::{build_dag, build_dag_layer, committee, drop_leader},
+};
+
+#[test]
+#[tracing_test::traced_test]
+fn fast_missed_weak_indirect_commit_n4() {
+    run_for_size(4);
+}
+
+#[test]
+#[tracing_test::traced_test]
+fn fast_missed_weak_indirect_commit_n20() {
+    run_for_size(20);
+}
+
+fn run_for_size(n: usize) {
+    let committee = committee(n);
+    let leader_counts = [1, 2, 2 * n / 3 + 1, n];
+    for spec in ConsensusProtocol::all_fast_path_for_test(n, &leader_counts) {
+        run(&spec, &committee);
+    }
+}
+
+fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
+    let protocol = spec.to_protocol(committee).expect("valid protocol");
+    let fast_path = protocol.fast_path.expect("fast-path protocol");
+    let k = protocol.leader_count.get();
+    let elector = LeaderElector::new(committee.len());
+
+    for target_offset in 0..k {
+        let mut storage = Storage::new_for_test(committee);
+        let mut committer = Committer::new_for_test(committee, &storage, spec);
+        let l1 = committer.nth_leader_round(1);
+        let decision_round = committer.decision_round_for(l1);
+        let target_leader = elector.elect_leader(l1 + target_offset as u64);
+
+        let l1_votes = build_dag(committee, &mut storage, None, l1);
+        let l1_blames = drop_leader(&l1_votes, target_leader);
+
+        // Voting layer: exactly the weak indirect quorum votes for the target.
+        let voters_count = fast_path.weak_indirect_quorum as usize;
+        let connections = committee
+            .authorities()
+            .enumerate()
+            .map(|(i, authority)| {
+                let parents = if i < voters_count {
+                    l1_votes.clone()
+                } else {
+                    l1_blames.clone()
+                };
+                (authority, parents)
+            })
+            .collect();
+        let voting_refs = build_dag_layer(connections, &mut storage);
+
+        // Fully-connected forward DAG up to the anchor's decision round: no
+        // decision block carries enough votes for a certificate, but the later
+        // anchor links every vote.
+        let anchor_round = committer.next_leader_round_after(decision_round);
+        let anchor_decision = committer.decision_round_for(anchor_round);
+        build_dag(committee, &mut storage, Some(voting_refs), anchor_decision);
+
+        let sequence = committer.try_commit(None).collect::<Vec<_>>();
+        tracing::info!("[{spec}] target_offset={target_offset} sequence: {sequence:?}");
+
+        assert!(
+            sequence.len() >= k,
+            "[{spec}] target_offset={target_offset} expected at least {k} decisions"
+        );
+        for (offset, decision) in sequence.iter().take(k).enumerate() {
+            let expected = elector.elect_leader(l1 + offset as u64);
+            if offset == target_offset {
+                match decision {
+                    LeaderStatus::IndirectCommit(block) => {
+                        assert_eq!(
+                            block.author(),
+                            expected,
+                            "[{spec}] target_offset={target_offset}"
+                        );
+                    }
+                    other => panic!(
+                        "[{spec}] target_offset={target_offset} expected IndirectCommit at \
+                        offset {offset}, got {other:?}"
+                    ),
+                }
+            } else {
+                match decision {
+                    LeaderStatus::DirectCommit(block) => {
+                        assert_eq!(
+                            block.author(),
+                            expected,
+                            "[{spec}] target_offset={target_offset} offset={offset}"
+                        );
+                    }
+                    other => panic!(
+                        "[{spec}] target_offset={target_offset} expected DirectCommit at \
+                        offset {offset}, got {other:?}"
+                    ),
+                }
+            }
+        }
+    }
+}

--- a/crates/dag/src/block.rs
+++ b/crates/dag/src/block.rs
@@ -137,6 +137,16 @@ impl Block {
         }
     }
 
+    /// Override the digest of a test block. The synthetic digest of
+    /// [`Block::new_for_test`] is keyed by `(round, authority)` alone, so two
+    /// same-slot blocks collapse into one reference; tests that need
+    /// distinguishable blocks (e.g. an equivocating pair) set their own digest.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn with_digest(mut self, digest: BlockDigest) -> Self {
+        self.reference.digest = digest;
+        self
+    }
+
     /// Verify the integrity and validity of a block received from the network.
     pub fn verify(
         &self,

--- a/crates/dag/src/crypto/digest.rs
+++ b/crates/dag/src/crypto/digest.rs
@@ -88,6 +88,14 @@ impl BlockDigest {
     }
 }
 
+/// Test-only escape hatch to spell a digest directly.
+#[cfg(any(test, feature = "test-utils"))]
+impl From<[u8; BLOCK_DIGEST_SIZE]> for BlockDigest {
+    fn from(bytes: [u8; BLOCK_DIGEST_SIZE]) -> Self {
+        Self(bytes)
+    }
+}
+
 impl AsRef<[u8]> for BlockDigest {
     #[inline]
     fn as_ref(&self) -> &[u8] {

--- a/crates/dag/src/test_util.rs
+++ b/crates/dag/src/test_util.rs
@@ -131,6 +131,16 @@ pub fn build_dag_layer(
     references
 }
 
+/// Insert a hand-built test block and return its reference. The door for
+/// blocks the layer builders cannot express (e.g. an equivocating block built
+/// with [`Block::with_digest`]).
+pub fn insert_test_block(block: Block, storage: &mut Storage) -> BlockReference {
+    let block = Data::new(block);
+    let reference = *block.reference();
+    storage.insert_block(block);
+    reference
+}
+
 /// Return the references at a round excluding the given leader's block.
 /// Convenience for tests that need to drive a "leader missed its proposal"
 /// scenario over an existing layer of refs.

--- a/crates/dag/src/test_util.rs
+++ b/crates/dag/src/test_util.rs
@@ -131,9 +131,9 @@ pub fn build_dag_layer(
     references
 }
 
-/// Insert a hand-built test block and return its reference. The door for
-/// blocks the layer builders cannot express (e.g. an equivocating block built
-/// with [`Block::with_digest`]).
+/// Insert a hand-built test block and return its reference. Use this for
+/// blocks the layer builders cannot express, such as an equivocating block
+/// built with [`Block::with_digest`].
 pub fn insert_test_block(block: Block, storage: &mut Storage) -> BlockReference {
     let block = Data::new(block);
     let reference = *block.reference();

--- a/crates/simulator/examples/single.yaml
+++ b/crates/simulator/examples/single.yaml
@@ -33,6 +33,7 @@ replica_parameters:
   #   orcaella                             { leader_count, f, c }
   #   mahi-mahi                            { leader_count, wave_length: 4 | 5 }
   #   nemo-nemo                            { leader_count }
+  #   dag-hydrangea                        { leader_count, f, c, k }
   #   cordial-miners-partially-synchronous
   #   cordial-miners-asynchronous
   consensus:

--- a/crates/simulator/tests/orcaella.rs
+++ b/crates/simulator/tests/orcaella.rs
@@ -261,12 +261,20 @@ fn infeasible_params_rejected() {
     let result = Protocol::orcaella(4, 1, 0, NonZeroUsize::new(1).unwrap());
     assert!(matches!(
         result,
-        Err(ProtocolError::OrcaellaFaultBoundViolated { n: 4, f: 1, c: 0 })
+        Err(ProtocolError::FaultBoundViolated {
+            protocol: "Orcaella",
+            n: 4,
+            min_n: 6,
+        })
     ));
     // CFT: n=2, f=0, c=1 needs n >= 2*1+1 = 3 — rejected
     let result = Protocol::orcaella(2, 0, 1, NonZeroUsize::new(1).unwrap());
     assert!(matches!(
         result,
-        Err(ProtocolError::OrcaellaFaultBoundViolated { n: 2, f: 0, c: 1 })
+        Err(ProtocolError::FaultBoundViolated {
+            protocol: "Orcaella",
+            n: 2,
+            min_n: 3,
+        })
     ));
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -243,7 +243,8 @@ the full lifetime of the process.
 
 The two regimes correspond to the two families of protocols:
 
-- **Partially-synchronous / leader-waiting** — Mysticeti, Cordial Miners (partially synchronous).
+- **Partially-synchronous / leader-waiting** — Mysticeti and every other protocol not listed
+  below.
   The committer's `get_leaders(round)` returns `Some(leaders)`. Before proposing at round `r+1`, the
   core checks that **every connected expected leader** at round `r` has already published its
   block. If not, the proposer waits up to the round timeout (default **1 s**) for the laggard


### PR DESCRIPTION
Supersedes #198, which was auto-closed when its base branch was deleted after #196 merged (the branch was since rebased onto main; identical content, all #198 review threads were addressed and resolved — including overflow-safe threshold arithmetic and the test-only digest escape hatch).

## Summary

Adds **DagHydrangea** — the DAG port of Hydrangea (Shrestha, Kate, Nayak; USENIX Sec '26): Mysticeti's certified slow path plus an optimistic fast path committing from `n − p` votes in two rounds, reconciled by the graded indirect rule. Implements #191 on the seams from #189/#196.

Parameters `n = 3f + 2c + k + 1`, derived `p = ⌊(c+k)/2⌋`:

| field | value | role |
| --- | --- | --- |
| `fast_path.commit_quorum` | `n − p` | fast direct commit (votes @ r+1) |
| `certificate_quorum` | `⌈(n+f+1)/2⌉` | certificate inner (uniqueness `2·CERT > n+f`) |
| `direct_commit_quorum` | `2f + c + 1` | slow-commit outer (durability) |
| `fast_path.weak_indirect_quorum` | `f + p + 1` | graded indirect rung 2 |
| `direct_skip_quorum` | `n − p` | opportunistic skip (graded rule backstops) |
| `quorum_threshold` | `n − f − c` | pacemaker / parents (availability) |

The three quorums coincide at `k = 0` and all diverge from `k ≥ 1`; the constructor validates the fault bound in overflow-safe (u128) arithmetic via the generalized `FaultBoundViolated` error and asserts the uniqueness/consistency inequalities.

## Tests

- Six `(f, c, k)` configurations join `all_for_test` (Byzantine-only, crash-only, mixed; `k = 2` and `k = 5` where all three quorums are distinct) — all 12 existing scenarios pass unchanged.
- Four fast-path scenario suites over `all_fast_path_for_test`: fast taken (decision round absent); fast missed → slow; fast missed with no certificate → weak-rung indirect commit; equivocation where the certified block beats a conflicting weak-quorum block. Quorum-unreachable configurations are skipped explicitly as protocol properties.
- Equivocation made constructible in tests via `Block::with_digest` + a test-gated `From<[u8; 32]> for BlockDigest` + `test_util::insert_test_block` (the synthetic test digest is keyed by `(round, authority)`, so same-slot blocks collapsed into one reference).
- Threshold arithmetic pinned against the design note's reference values.

## End-to-end

20 s local testbed (n = 4, f = 1, 2 leaders/round): ~43k committed leaders, commits consistent across all replicas, p50 latency 50 ms.

Closes #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)