### PR TITLE
docs(readme): list DAG version of Hydrangea among supported protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repository currently supports [Mysticeti](https://sonnino.com/papers/mystic
 [Mahi-Mahi](https://sonnino.com/papers/mahi-mahi.pdf),
 [Blue Bottle](https://sonnino.com/papers/bluebottle.pdf), [Cordial
 Miners](https://arxiv.org/abs/2205.09174) (both the partially synchronous and asynchronous
-variants), [Nemo-Nemo](https://sonnino.com/papers/nemo-nemo.pdf), and [Orcaella](https://sonnino.com/papers/orcaella.pdf).
+variants), [Nemo-Nemo](https://sonnino.com/papers/nemo-nemo.pdf), [Orcaella](https://sonnino.com/papers/orcaella.pdf), and a DAG variant of [Hydrangea](https://eprint.iacr.org/2025/1112).
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ This repository currently supports [Mysticeti](https://sonnino.com/papers/mystic
 [Mahi-Mahi](https://sonnino.com/papers/mahi-mahi.pdf),
 [Blue Bottle](https://sonnino.com/papers/bluebottle.pdf), [Cordial
 Miners](https://arxiv.org/abs/2205.09174) (both the partially synchronous and asynchronous
-variants), [Nemo-Nemo](https://sonnino.com/papers/nemo-nemo.pdf), [Orcaella](https://sonnino.com/papers/orcaella.pdf), and a DAG variant of [Hydrangea](https://eprint.iacr.org/2025/1112).
+variants), [Nemo-Nemo](https://sonnino.com/papers/nemo-nemo.pdf),
+[Orcaella](https://sonnino.com/papers/orcaella.pdf), and a DAG variant of
+[Hydrangea](https://eprint.iacr.org/2025/1112).
 
 ## Quick Start
 


### PR DESCRIPTION
Mention that the repository also implements a DAG version of [Hydrangea](https://eprint.iacr.org/2025/1112) in the supported-protocols list of the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)