### PR TITLE
feat(replica): executor-agnostic transaction submission via TransactionClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4073,6 +4073,7 @@ dependencies = [
  "replica",
  "serde",
  "serde_yaml",
+ "simulator",
  "tempfile",
  "tokio",
  "tracing",

--- a/crates/dag/src/block/transaction.rs
+++ b/crates/dag/src/block/transaction.rs
@@ -52,7 +52,8 @@ impl Transaction {
         Self::new(payload.into())
     }
 
-    /// True iff this transaction was produced by [`Transaction::new_for_test`].
+    /// True if the payload ends with the test marker written by
+    /// [`Transaction::new_for_test`].
     pub fn has_test_marker(&self) -> bool {
         self.data.ends_with(&Self::TEST_MARKER)
     }

--- a/crates/dag/src/block/transaction.rs
+++ b/crates/dag/src/block/transaction.rs
@@ -44,7 +44,8 @@ impl Transaction {
 impl Transaction {
     const TEST_MARKER: [u8; 8] = [0xAB; 8];
 
-    /// A benchmark-shaped transaction (timestamp prefix) carrying a recognizable marker.
+    /// A transaction whose first 8 bytes decode as a (zero) timestamp, followed by a
+    /// recognizable marker.
     pub fn new_for_test() -> Self {
         let mut payload = vec![0u8; 16];
         payload[8..].copy_from_slice(&Self::TEST_MARKER);

--- a/crates/dag/src/block/transaction.rs
+++ b/crates/dag/src/block/transaction.rs
@@ -40,6 +40,23 @@ impl Transaction {
     }
 }
 
+#[cfg(any(test, feature = "test-utils"))]
+impl Transaction {
+    const TEST_MARKER: [u8; 8] = [0xAB; 8];
+
+    /// A benchmark-shaped transaction (timestamp prefix) carrying a recognizable marker.
+    pub fn new_for_test() -> Self {
+        let mut payload = vec![0u8; 16];
+        payload[8..].copy_from_slice(&Self::TEST_MARKER);
+        Self::new(payload.into())
+    }
+
+    /// True iff this transaction was produced by [`Transaction::new_for_test`].
+    pub fn has_test_marker(&self) -> bool {
+        self.data.ends_with(&Self::TEST_MARKER)
+    }
+}
+
 impl AsBytes for Transaction {
     fn as_bytes(&self) -> &[u8] {
         &self.data

--- a/crates/replica/src/client.rs
+++ b/crates/replica/src/client.rs
@@ -5,8 +5,8 @@ use dag::block::transaction::Transaction;
 use eyre::{Result, eyre};
 use tokio::sync::mpsc;
 
-/// Cloneable handle for submitting transactions to a running replica, independent of the
-/// [`ReplicaHandle`](crate::replica::ReplicaHandle)'s lifetime.
+/// Cloneable handle for submitting transactions to a running replica. Shutting the replica
+/// down closes the channel.
 #[derive(Clone)]
 pub struct TransactionClient {
     sender: mpsc::Sender<Vec<Transaction>>,

--- a/crates/replica/src/client.rs
+++ b/crates/replica/src/client.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use dag::block::transaction::Transaction;
+use eyre::{Result, eyre};
+use tokio::sync::mpsc;
+
+/// Cloneable handle for submitting transactions to a running replica, independent of the
+/// [`ReplicaHandle`]'s lifetime.
+#[derive(Clone)]
+pub struct TransactionClient {
+    sender: mpsc::Sender<Vec<Transaction>>,
+}
+
+impl TransactionClient {
+    pub(crate) fn new(sender: mpsc::Sender<Vec<Transaction>>) -> Self {
+        Self { sender }
+    }
+
+    /// Submit a batch of transactions. Resolves once the batch is queued for inclusion in a
+    /// future block (not once committed). Errors iff the replica has shut down.
+    ///
+    /// Under `SimulatorContext`, this future must be awaited from a task running inside the
+    /// simulated world (spawned via `Ctx::spawn`).
+    pub async fn submit(&self, transactions: Vec<Transaction>) -> Result<()> {
+        self.sender
+            .send(transactions)
+            .await
+            .map_err(|_| eyre!("Transaction channel closed"))
+    }
+}

--- a/crates/replica/src/client.rs
+++ b/crates/replica/src/client.rs
@@ -6,7 +6,7 @@ use eyre::{Result, eyre};
 use tokio::sync::mpsc;
 
 /// Cloneable handle for submitting transactions to a running replica, independent of the
-/// [`ReplicaHandle`]'s lifetime.
+/// [`ReplicaHandle`](crate::replica::ReplicaHandle)'s lifetime.
 #[derive(Clone)]
 pub struct TransactionClient {
     sender: mpsc::Sender<Vec<Transaction>>,

--- a/crates/replica/src/generator.rs
+++ b/crates/replica/src/generator.rs
@@ -5,14 +5,13 @@ use std::{mem, sync::Arc, time::Duration};
 
 use minibytes::Bytes;
 use rand::{Rng, SeedableRng, rngs::StdRng};
-use tokio::sync::mpsc;
 
 use dag::{authority::Authority, block::transaction::Transaction, context::Ctx, metrics::Metrics};
 
-use crate::config::LoadGeneratorConfig;
+use crate::{client::TransactionClient, config::LoadGeneratorConfig};
 
 pub struct TransactionGenerator {
-    sender: mpsc::Sender<Vec<Transaction>>,
+    client: TransactionClient,
     max_block_size: usize,
     metrics: Arc<Metrics>,
 }
@@ -22,7 +21,7 @@ impl TransactionGenerator {
     const HEADER_SIZE: usize = 8 + 8; // timestamp + random
 
     pub fn start<C: Ctx>(
-        sender: mpsc::Sender<Vec<Transaction>>,
+        client: TransactionClient,
         seed: Authority,
         config: LoadGeneratorConfig,
         max_block_size: usize,
@@ -42,7 +41,7 @@ impl TransactionGenerator {
         let random = rng.r#gen();
         C::spawn(
             Self {
-                sender,
+                client,
                 max_block_size,
                 metrics,
             }
@@ -86,14 +85,14 @@ impl TransactionGenerator {
 
             if block_size >= self.max_block_size {
                 let full_block = mem::replace(&mut block, Vec::with_capacity(block_capacity));
-                if self.sender.send(full_block).await.is_err() {
+                if self.client.submit(full_block).await.is_err() {
                     return false;
                 }
                 block_size = 0;
             }
         }
         if !block.is_empty() {
-            return self.sender.send(block).await.is_ok();
+            return self.client.submit(block).await.is_ok();
         }
         true
     }

--- a/crates/replica/src/lib.rs
+++ b/crates/replica/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod builder;
+pub mod client;
 pub mod config;
 pub mod generator;
 pub mod prometheus;

--- a/crates/replica/src/replica.rs
+++ b/crates/replica/src/replica.rs
@@ -178,7 +178,8 @@ impl<C: Ctx> ReplicaHandle<C> {
         )
     }
 
-    /// Submit transactions externally.
+    /// Submit transactions externally. See [`TransactionClient::submit`] for the simulation
+    /// caveat.
     pub async fn submit(&self, transactions: Vec<Transaction>) -> Result<()> {
         self.transaction_client.submit(transactions).await
     }

--- a/crates/replica/src/replica.rs
+++ b/crates/replica/src/replica.rs
@@ -11,7 +11,7 @@ use consensus::committer::Committer;
 use dag::{
     authority::Authority,
     block::transaction::Transaction,
-    context::{Ctx, TokioCtx},
+    context::Ctx,
     core::{
         Core,
         block_handler::{CommitHandler, RealBlockHandler},
@@ -23,10 +23,10 @@ use dag::{
     sync::{net_sync::NetworkSyncer, network::Network},
 };
 use eyre::{Context, Result, eyre};
-use tokio::sync::mpsc;
 
 use crate::{
     builder::StorageKind,
+    client::TransactionClient,
     config::{LoadGeneratorConfig, PrivateReplicaConfig, PublicReplicaConfig},
     generator::TransactionGenerator,
 };
@@ -140,7 +140,7 @@ impl Replica {
             public_config,
             network_synchronizer,
             metrics,
-            transaction_sender,
+            transaction_client: TransactionClient::new(transaction_sender),
         })
     }
 }
@@ -151,10 +151,8 @@ pub struct ReplicaHandle<C: Ctx> {
     public_config: PublicReplicaConfig,
     network_synchronizer: NetworkSyncer<C, Committer>,
     metrics: Arc<Metrics>,
-    /// Channel for submitting transactions to the block handler. Cloned into the built-in load
-    /// generator when one is started (see [`ReplicaHandle::start_load_generator`]) and reachable
-    /// externally via [`ReplicaHandle::submit`] on `TokioCtx`.
-    transaction_sender: mpsc::Sender<Vec<Transaction>>,
+    /// Client over the channel for submitting transactions to the block handler.
+    transaction_client: TransactionClient,
 }
 
 impl<C: Ctx> ReplicaHandle<C> {
@@ -169,27 +167,25 @@ impl<C: Ctx> ReplicaHandle<C> {
     }
 
     /// Start the built-in load generator. Transactions from the generator and from
-    /// [`ReplicaHandle::submit`] (on `TokioCtx`) share the same channel and are interleaved
-    /// in arrival order. Returns the task handle; drop it to detach, or keep it to abort
-    /// later via `C::abort`.
+    /// [`ReplicaHandle::submit`] share the same channel and are interleaved.
     pub fn start_load_generator(&mut self, config: LoadGeneratorConfig) -> C::JoinHandle<()> {
         TransactionGenerator::start::<C>(
-            self.transaction_sender.clone(),
+            self.transaction_client.clone(),
             self.authority,
             config,
             self.public_config.parameters.dag.max_block_size,
             self.metrics.clone(),
         )
     }
-}
 
-impl ReplicaHandle<TokioCtx> {
     /// Submit transactions externally.
     pub async fn submit(&self, transactions: Vec<Transaction>) -> Result<()> {
-        self.transaction_sender
-            .send(transactions)
-            .await
-            .map_err(|_| eyre!("Transaction channel closed"))
+        self.transaction_client.submit(transactions).await
+    }
+
+    /// A cloneable client for submitting transactions; outlives borrows of the handle.
+    pub fn transaction_client(&self) -> TransactionClient {
+        self.transaction_client.clone()
     }
 
     /// Wait for the replica to finish.
@@ -197,6 +193,6 @@ impl ReplicaHandle<TokioCtx> {
         self.network_synchronizer
             .await_completion()
             .await
-            .map_err(|error| eyre!("Replica {} crashed: {error}", self.authority))
+            .map_err(|error| eyre!("Replica {} crashed: {error:?}", self.authority))
     }
 }

--- a/crates/simulator/Cargo.toml
+++ b/crates/simulator/Cargo.toml
@@ -21,4 +21,8 @@ parking_lot = { workspace = true }
 
 [dev-dependencies]
 indoc = { workspace = true }
+simulator = { path = ".", features = ["test-utils"] }
 tempfile = { workspace = true }
+
+[features]
+test-utils = []

--- a/crates/simulator/src/runner.rs
+++ b/crates/simulator/src/runner.rs
@@ -11,7 +11,6 @@ use std::{
 use consensus::committer::Committer;
 use dag::{
     authority::Authority,
-    committee::Committee,
     config::{ConfigError, ImportExport},
     context::Ctx,
     core::syncer::Syncer,
@@ -88,8 +87,7 @@ impl SimulatedNetwork {
         let public_config = PublicReplicaConfig::new_for_tests(committee_size);
         let latency_range = Duration::from_millis(50)..Duration::from_millis(100);
         let (network, replicas, _) =
-            SimulationState::build_replicas(committee_size, public_config, latency_range, None)
-                .await;
+            SimulationState::build_replicas(public_config, latency_range, None).await;
         network.connect_all().await;
         (network, replicas)
     }
@@ -98,7 +96,6 @@ impl SimulatedNetwork {
 impl SimulationState {
     /// Build a committee of simulated replicas wired through a [`SimulatedNetwork`].
     async fn build_replicas(
-        committee_size: usize,
         public_config: PublicReplicaConfig,
         latency_range: Range<Duration>,
         load_generator: Option<LoadGeneratorConfig>,
@@ -107,7 +104,8 @@ impl SimulationState {
         Vec<ReplicaHandle<SimulatorContext>>,
         Vec<JoinHandle<()>>,
     ) {
-        let committee = Committee::new_test(vec![1; committee_size]);
+        let committee = public_config.committee();
+        let committee_size = committee.len();
         let (network, networks) = SimulatedNetwork::new(&committee, latency_range);
 
         // The simulator doesn't touch disk; the WAL path in the private
@@ -143,7 +141,6 @@ impl SimulationState {
         let public_config = PublicReplicaConfig::new_for_tests(config.committee_size)
             .with_parameters(config.replica_parameters.clone());
         let (network, replicas, load_generators) = Self::build_replicas(
-            config.committee_size,
             public_config,
             config.latency_range(),
             config.load_generator.clone(),

--- a/crates/simulator/src/runner.rs
+++ b/crates/simulator/src/runner.rs
@@ -3,7 +3,9 @@
 
 use std::{
     io,
+    ops::Range,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use consensus::committer::Committer;
@@ -19,7 +21,7 @@ use dag::{
 use rand::{SeedableRng, rngs::StdRng};
 use replica::{
     builder::{ReplicaBuilder, StorageKind},
-    config::{PrivateReplicaConfig, PublicReplicaConfig},
+    config::{LoadGeneratorConfig, PrivateReplicaConfig, PublicReplicaConfig},
     replica::ReplicaHandle,
     result::{RunKind, RunResult},
 };
@@ -76,15 +78,37 @@ struct SimulationState {
     _load_generators: Vec<JoinHandle<()>>,
 }
 
+impl SimulatedNetwork {
+    /// A fully connected committee with default parameters. The returned network must be
+    /// kept alive for the duration of the run.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub async fn new_for_test(
+        committee_size: usize,
+    ) -> (Self, Vec<ReplicaHandle<SimulatorContext>>) {
+        let public_config = PublicReplicaConfig::new_for_tests(committee_size);
+        let latency_range = Duration::from_millis(50)..Duration::from_millis(100);
+        let (network, replicas, _) =
+            SimulationState::build_replicas(committee_size, public_config, latency_range, None)
+                .await;
+        network.connect_all().await;
+        (network, replicas)
+    }
+}
+
 impl SimulationState {
-    async fn setup(config: SimulationConfig) -> Self {
-        let committee_size = config.committee_size;
+    /// Build a committee of simulated replicas wired through a [`SimulatedNetwork`].
+    async fn build_replicas(
+        committee_size: usize,
+        public_config: PublicReplicaConfig,
+        latency_range: Range<Duration>,
+        load_generator: Option<LoadGeneratorConfig>,
+    ) -> (
+        SimulatedNetwork,
+        Vec<ReplicaHandle<SimulatorContext>>,
+        Vec<JoinHandle<()>>,
+    ) {
         let committee = Committee::new_test(vec![1; committee_size]);
-
-        let public_config = PublicReplicaConfig::new_for_tests(committee_size)
-            .with_parameters(config.replica_parameters.clone());
-
-        let (network, networks) = SimulatedNetwork::new(&committee, config.latency_range());
+        let (network, networks) = SimulatedNetwork::new(&committee, latency_range);
 
         // The simulator doesn't touch disk; the WAL path in the private
         // configs is unused once we override storage with `InMemory`.
@@ -107,11 +131,24 @@ impl SimulationState {
                 .run::<SimulatorContext>()
                 .await
                 .expect("simulator replica build must not fail");
-            if let Some(load_generator) = config.load_generator.clone() {
+            if let Some(load_generator) = load_generator.clone() {
                 load_generators.push(handle.start_load_generator(load_generator));
             }
             replicas.push(handle);
         }
+        (network, replicas, load_generators)
+    }
+
+    async fn setup(config: SimulationConfig) -> Self {
+        let public_config = PublicReplicaConfig::new_for_tests(config.committee_size)
+            .with_parameters(config.replica_parameters.clone());
+        let (network, replicas, load_generators) = Self::build_replicas(
+            config.committee_size,
+            public_config,
+            config.latency_range(),
+            config.load_generator.clone(),
+        )
+        .await;
 
         Self {
             config,

--- a/crates/simulator/tests/transaction_client.rs
+++ b/crates/simulator/tests/transaction_client.rs
@@ -35,7 +35,9 @@ fn submitter_task_inside_simulation() {
             .collect();
 
         SimulatorContext::sleep(Duration::from_secs(20)).await;
-        drop(submitters);
+        for submitter in &submitters {
+            SimulatorContext::abort(submitter);
+        }
 
         let syncers = join_all(replicas.into_iter().map(ReplicaHandle::shutdown)).await;
         syncers.into_iter().all(|syncer| {

--- a/crates/simulator/tests/transaction_client.rs
+++ b/crates/simulator/tests/transaction_client.rs
@@ -1,0 +1,62 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use futures::future::join_all;
+use rand::{SeedableRng, rngs::StdRng};
+
+use dag::{block::transaction::Transaction, context::Ctx};
+use replica::replica::ReplicaHandle;
+use simulator::{SimulatedNetwork, SimulatorContext, SimulatorExecutor};
+
+/// Externally submitted transactions must flow through to commit on every node when the
+/// submitter runs as a task inside the simulated world.
+#[test]
+fn submitter_task_inside_simulation() {
+    let rng = StdRng::seed_from_u64(42);
+    let all_nodes_committed_marker = SimulatorExecutor::run(rng, async move {
+        let (_network, replicas) = SimulatedNetwork::new_for_test(4).await;
+
+        let submitters: Vec<_> = replicas
+            .iter()
+            .map(|handle| {
+                let client = handle.transaction_client();
+                SimulatorContext::spawn(async move {
+                    while client
+                        .submit(vec![Transaction::new_for_test()])
+                        .await
+                        .is_ok()
+                    {
+                        SimulatorContext::sleep(Duration::from_millis(100)).await;
+                    }
+                })
+            })
+            .collect();
+
+        SimulatorContext::sleep(Duration::from_secs(20)).await;
+        drop(submitters);
+
+        let syncers = join_all(replicas.into_iter().map(ReplicaHandle::shutdown)).await;
+        syncers.into_iter().all(|syncer| {
+            let storage = syncer.into_storage();
+            storage.iter_commits().any(|commit| {
+                commit.sub_dag.iter().any(|reference| {
+                    storage
+                        .block_reader()
+                        .get_block(*reference)
+                        .is_some_and(|block| {
+                            block
+                                .transactions()
+                                .iter()
+                                .any(Transaction::has_test_marker)
+                        })
+                })
+            })
+        })
+    });
+    assert!(
+        all_nodes_committed_marker,
+        "every node must commit at least one externally submitted transaction"
+    );
+}


### PR DESCRIPTION
Phase 1 of #208 (see the issue for the full multi-PR plan).

- Move `ReplicaHandle::submit` and `await_completion` from the `TokioCtx`-gated impl to the generic `impl<C: Ctx>` — no TokioCtx-gated surface remains on the handle. (`await_completion` error formatting changes from `{error}` to `{error:?}` since `C::JoinError` is only bound to `Debug`.)
- New cloneable `TransactionClient` (`crates/replica/src/client.rs`) wrapping the bounded transaction channel, obtainable via `ReplicaHandle::transaction_client()`, so an embedding validator can hand submission capability to its mempool/RPC layer independently of the handle's lifetime.
- The load generator now submits through `TransactionClient` — the external path and the benchmark path are the same code.
- `Transaction::new_for_test` / `has_test_marker` (test-utils gated) for payload round-trip assertions.
- `SimulatedNetwork::new_for_test` (test-utils gated, backed by a private `build_replicas` also used by `SimulationState::setup`) builds a connected simulated committee for tests; production wiring and task-spawn ordering unchanged.
- New simulator test: externally spawned submitter tasks inside the simulated world drive transactions to commit on every node.

No consumer-facing behavior changes on the production path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)