### PR TITLE
feat(dag,replica): stream committed sub-dags to an embedder-provided consumer

### DIFF
--- a/.claude/agent-memory/refactor-guardian/MEMORY.md
+++ b/.claude/agent-memory/refactor-guardian/MEMORY.md
@@ -7,3 +7,4 @@
 - [Committer cursor must track skips](project_committer_cursor_semantics.md) — Core.last_decided advances on every yielded leader (commit + skip); advancing only on commits double-counts trailing-skip metrics
 - [ready_new_block gate post-last_decided](project_ready_new_block_gate.md) — gate uses last_decided_round, which is >= old commit-only round, so the gate is bounded-less-eager (≤ wave_length - 1 rounds)
 - [#189 fast-path seams](project_189_fast_path_seams.md) — dual-path committer extension; equal-by-construction quorum invariant, inert Option<FastPath> guards, cfg-gating + feature-unification gotchas
+- [#208 commit-consumer seam](project_208_commit_consumer_seam.md) — opt-in CommittedSubDag output channel; None-path inertness, two-sender drain, single-threaded simulator determinism

--- a/.claude/agent-memory/refactor-guardian/project_208_commit_consumer_seam.md
+++ b/.claude/agent-memory/refactor-guardian/project_208_commit_consumer_seam.md
@@ -1,0 +1,46 @@
+---
+name: 208-commit-consumer-seam
+description: "Issue #208 Phase 2 opt-in commit-consumer output seam; None-path inertness reasoning + two-sender drain + simulator determinism argument"
+type: project
+---
+
+Issue #208 Phase 2 (branch `commit-consumer`) adds an opt-in output seam that streams every
+`CommittedSubDag` to a bounded `mpsc::Sender` after its WAL write. Core/syncer stay synchronous.
+Related seam-audit pattern to [[189-fast-path-seams]].
+
+**Commit-production call chain (every producer must forward):** `Syncer::add_blocks` /
+`force_new_block` / `try_new_block` now return `Vec<CommittedSubDag>` (previously dropped).
+`Core::handle_committed_subdag` returns its *input* `committed` back (was returning the throwaway
+`Vec<CommitData>` built for `write_commits`; only 2 refs, caller discarded it). The ONLY Syncer
+commit-producers are: `CoreThread` AddBlocks/ForceNewBlock arms (`core_thread.rs`), `InlineDispatcher`
+add_blocks/force_new_block (`dispatcher.rs`), and the `NetworkSyncer::start` startup `force_new_block(0)`
+(`net_sync.rs:79`, forwarded at top of `run()`). Core::add_blocks / Core::try_new_block and the
+`replica/tests/core.rs` calls are on `Core`, NOT `Syncer` — unchanged, don't confuse.
+
+**None-path inertness argument (why it's byte-equivalent):** With `commit_consumer = None`, the
+returned Vec is just *moved* up the stack (never cloned) and dropped in `forward_commits` after one
+always-false `let Some(consumer) = ... else { return }`. `handle_committed_subdag` still builds
+`commit_data` for the WAL and drops it at fn end (previously it dropped the input `committed` at fn
+end and returned commit_data — symmetric, same alloc/drop count). Empty Vecs don't allocate. No
+metric touched (`inc_leader_timeout` unchanged condition; utilization_timers unchanged). No WAL
+ordering change.
+
+**Two-sender drain (shutdown correctness):** `NetworkSyncer::start` gives `create_dispatcher` a
+`commit_consumer.clone()` and moves the original into `run()`. So the channel has TWO Sender handles:
+(1) `run()`'s local, dropped when `main_task` completes; (2) the dispatcher's, dropped when
+`ThreadedDispatcher::stop` joins the core thread (CoreThread's `run` returns `self.syncer`, dropping
+the rest incl. its sender) or `InlineDispatcher::stop` calls `into_inner`. A drain loop
+(`while receiver.recv().await`) only terminates after BOTH drop — i.e. after full `shutdown()`.
+
+**Backpressure/deadlock:** `blocking_send` runs only on the dedicated core `std::thread` (owns syncer,
+holds no other lock). `InlineDispatcher` awaits `send` while holding the tokio syncer `Mutex`
+(intentional, for commit-order + backpressure); consumer never needs the syncer lock, so no deadlock.
+A non-draining full consumer blocks the replica by design.
+
+**Simulator determinism:** `dispatcher.rs` swapped `parking_lot::Mutex` -> `tokio::sync::Mutex`
+(+ removed the `parking_lot` dep from `simulator/Cargo.toml`; grep-confirmed no other simulator use).
+The executor is single-threaded (thread-local `RefCell` scheduler in `event_simulator.rs`), so locks
+are never truly contended. On the None path `forward_commits().await` and `lock().await` resolve
+Ready on first poll (no Pending, no executor yield), so the event schedule is unchanged. Startup
+commits are forwarded at the top of `run()` before `round_timeout_task`/`cleanup_task`/connection tasks
+spawn, guaranteeing startup-before-steady-state ordering.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4068,7 +4068,6 @@ dependencies = [
  "eyre",
  "futures",
  "indoc",
- "parking_lot",
  "rand 0.8.5",
  "replica",
  "serde",

--- a/crates/dag/src/context.rs
+++ b/crates/dag/src/context.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, future::Future, time::Duration};
 
 use tokio::sync::{mpsc, oneshot};
 
-use crate::consensus::DagConsensus;
+use crate::consensus::{CommittedSubDag, DagConsensus};
 use crate::core::core_thread::{CoreDispatch, ThreadedDispatcher};
 use crate::core::syncer::Syncer;
 use crate::storage::WalSyncer;
@@ -32,7 +32,10 @@ pub trait Ctx: Sized + Send + Sync + 'static {
     fn abort<T: Send + 'static>(handle: &Self::JoinHandle<T>);
 
     type Dispatcher<D: DagConsensus>: CoreDispatch<Self, D>;
-    fn create_dispatcher<D: DagConsensus>(syncer: Syncer<Self, D>) -> Self::Dispatcher<D>;
+    fn create_dispatcher<D: DagConsensus>(
+        syncer: Syncer<Self, D>,
+        commit_consumer: Option<mpsc::Sender<CommittedSubDag>>,
+    ) -> Self::Dispatcher<D>;
 
     fn start_wal_syncer(wal_syncer: WalSyncer, stop: mpsc::Sender<()>) -> oneshot::Receiver<()>;
 }
@@ -85,8 +88,11 @@ impl Ctx for TokioCtx {
 
     type Dispatcher<D: DagConsensus> = ThreadedDispatcher<Self, D>;
 
-    fn create_dispatcher<D: DagConsensus>(syncer: Syncer<Self, D>) -> Self::Dispatcher<D> {
-        ThreadedDispatcher::new(syncer)
+    fn create_dispatcher<D: DagConsensus>(
+        syncer: Syncer<Self, D>,
+        commit_consumer: Option<mpsc::Sender<CommittedSubDag>>,
+    ) -> Self::Dispatcher<D> {
+        ThreadedDispatcher::new(syncer, commit_consumer)
     }
 
     fn start_wal_syncer(wal_syncer: WalSyncer, stop: mpsc::Sender<()>) -> oneshot::Receiver<()> {

--- a/crates/dag/src/core.rs
+++ b/crates/dag/src/core.rs
@@ -359,10 +359,14 @@ impl<C: Ctx, D: DagConsensus> Core<C, D> {
         }
     }
 
-    pub fn handle_committed_subdag(&mut self, committed: Vec<CommittedSubDag>) -> Vec<CommitData> {
+    /// Durably record the committed sub-dags, then hand them back to the caller.
+    pub fn handle_committed_subdag(
+        &mut self,
+        committed: Vec<CommittedSubDag>,
+    ) -> Vec<CommittedSubDag> {
         let commit_data: Vec<_> = committed.iter().map(CommitData::from).collect();
         self.storage.write_commits(&commit_data);
-        commit_data
+        committed
     }
 
     pub fn take_recovered_committed_blocks(&mut self) -> HashSet<BlockReference> {

--- a/crates/dag/src/core/core_thread.rs
+++ b/crates/dag/src/core/core_thread.rs
@@ -9,7 +9,7 @@ use super::syncer::Syncer;
 use crate::{
     authority::Authority,
     block::{Block, BlockReference, RoundNumber},
-    consensus::DagConsensus,
+    consensus::{CommittedSubDag, DagConsensus},
     context::Ctx,
     data::Data,
     metrics::Metrics,
@@ -49,10 +49,17 @@ pub struct ThreadedDispatcher<C: Ctx, D: DagConsensus> {
 }
 
 impl<C: Ctx, D: DagConsensus> ThreadedDispatcher<C, D> {
-    pub fn new(syncer: Syncer<C, D>) -> Self {
+    pub fn new(
+        syncer: Syncer<C, D>,
+        commit_consumer: Option<mpsc::Sender<CommittedSubDag>>,
+    ) -> Self {
         let (sender, receiver) = mpsc::channel(32);
         let metrics = syncer.core().metrics.clone();
-        let core_thread = CoreThread { syncer, receiver };
+        let core_thread = CoreThread {
+            syncer,
+            receiver,
+            commit_consumer,
+        };
         let join_handle = thread::Builder::new()
             .name("dag".to_string())
             .spawn(move || core_thread.run())
@@ -117,6 +124,7 @@ impl<C: Ctx, D: DagConsensus> CoreDispatch<C, D> for ThreadedDispatcher<C, D> {
 struct CoreThread<C: Ctx, D: DagConsensus> {
     syncer: Syncer<C, D>,
     receiver: mpsc::Receiver<CoreThreadCommand>,
+    commit_consumer: Option<mpsc::Sender<CommittedSubDag>>,
 }
 
 impl<C: Ctx, D: DagConsensus> CoreThread<C, D> {
@@ -128,11 +136,13 @@ impl<C: Ctx, D: DagConsensus> CoreThread<C, D> {
             metrics.inc_core_lock_dequeued();
             match command {
                 CoreThreadCommand::AddBlocks(blocks, sender) => {
-                    self.syncer.add_blocks(blocks);
+                    let committed = self.syncer.add_blocks(blocks);
+                    self.forward_commits(committed);
                     sender.send(()).ok();
                 }
                 CoreThreadCommand::ForceNewBlock(round, sender) => {
-                    self.syncer.force_new_block(round);
+                    let committed = self.syncer.force_new_block(round);
+                    self.forward_commits(committed);
                     sender.send(()).ok();
                 }
                 CoreThreadCommand::Cleanup(sender) => {
@@ -154,5 +164,29 @@ impl<C: Ctx, D: DagConsensus> CoreThread<C, D> {
             }
         }
         self.syncer
+    }
+
+    /// Forward newly committed sub-dags to the consumer before acking the caller. Blocks the
+    /// core thread when the consumer is full, throttling the whole replica (backpressure);
+    /// blocked time is visible as `utilization{scope="CoreThread::forward_commits"}`.
+    fn forward_commits(&mut self, committed: Vec<CommittedSubDag>) {
+        let Some(consumer) = &self.commit_consumer else {
+            return;
+        };
+        if committed.is_empty() {
+            return;
+        }
+        let _timer = self
+            .syncer
+            .core()
+            .metrics
+            .utilization_timer("CoreThread::forward_commits");
+        for subdag in committed {
+            if consumer.blocking_send(subdag).is_err() {
+                tracing::warn!("Commit consumer dropped; halting commit forwarding");
+                self.commit_consumer = None;
+                return;
+            }
+        }
     }
 }

--- a/crates/dag/src/core/syncer.rs
+++ b/crates/dag/src/core/syncer.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use tokio::sync::Notify;
 
 use super::{Core, block_handler::CommitHandler};
-use crate::consensus::DagConsensus;
+use crate::consensus::{CommittedSubDag, DagConsensus};
 use crate::storage::Storage;
 use crate::{
     authority::Authority,
@@ -76,28 +76,29 @@ impl<C: Ctx, D: DagConsensus> Syncer<C, D> {
         }
     }
 
-    pub fn add_blocks(&mut self, blocks: Vec<Data<Block>>) {
+    /// Add blocks to the core, returning any sub-dags newly committed as a consequence.
+    pub fn add_blocks(&mut self, blocks: Vec<Data<Block>>) -> Vec<CommittedSubDag> {
         let _timer = self.metrics.utilization_timer("Syncer::add_blocks");
         self.core.add_blocks(blocks);
-        self.try_new_block();
+        self.try_new_block()
     }
 
-    pub fn force_new_block(&mut self, round: RoundNumber) -> bool {
+    /// Force a new block proposal, returning any sub-dags newly committed as a consequence.
+    pub fn force_new_block(&mut self, round: RoundNumber) -> Vec<CommittedSubDag> {
         if self.core.last_proposed() == round {
             self.metrics.inc_leader_timeout();
             self.force_new_block = true;
-            self.try_new_block();
-            true
+            self.try_new_block()
         } else {
-            false
+            Vec::new()
         }
     }
 
-    fn try_new_block(&mut self) {
+    fn try_new_block(&mut self) -> Vec<CommittedSubDag> {
         let _timer = self.metrics.utilization_timer("Syncer::try_new_block");
         if self.force_new_block || self.core.ready_new_block(&self.connected_authorities) {
             if self.core.try_new_block().is_none() {
-                return;
+                return Vec::new();
             }
             self.signals.new_block_ready();
             self.force_new_block = false;
@@ -117,7 +118,9 @@ impl<C: Ctx, D: DagConsensus> Syncer<C, D> {
             let committed_subdag = self
                 .commit_handler
                 .handle_commit(self.core.block_reader(), newly_committed);
-            self.core.handle_committed_subdag(committed_subdag);
+            self.core.handle_committed_subdag(committed_subdag)
+        } else {
+            Vec::new()
         }
     }
 

--- a/crates/dag/src/sync/net_sync.rs
+++ b/crates/dag/src/sync/net_sync.rs
@@ -13,7 +13,7 @@ use crate::{
     authority::Authority,
     committee::Committee,
     committee::Stake,
-    consensus::DagConsensus,
+    consensus::{CommittedSubDag, DagConsensus},
     context::Ctx,
     core::{
         Core,
@@ -59,6 +59,7 @@ impl<C: Ctx, D: DagConsensus> NetworkSyncer<C, D> {
         enable_synchronizer: bool,
         mut commit_handler: CommitHandler<C>,
         metrics: Arc<Metrics>,
+        commit_consumer: Option<mpsc::Sender<CommittedSubDag>>,
     ) -> Self {
         let authority_index = core.authority();
         let notify = Arc::new(Notify::new());
@@ -75,8 +76,8 @@ impl<C: Ctx, D: DagConsensus> NetworkSyncer<C, D> {
             commit_handler,
             metrics.clone(),
         );
-        syncer.force_new_block(0);
-        let syncer = C::create_dispatcher(syncer);
+        let startup_commits = syncer.force_new_block(0);
+        let syncer = C::create_dispatcher(syncer, commit_consumer.clone());
         let (stop_sender, stop_receiver) = mpsc::channel(1);
         // Occupy the only available permit, so that all
         // other calls to send() will block.
@@ -102,6 +103,8 @@ impl<C: Ctx, D: DagConsensus> NetworkSyncer<C, D> {
             inner.clone(),
             block_fetcher,
             metrics.clone(),
+            startup_commits,
+            commit_consumer,
         ));
         let syncer_task = C::start_wal_syncer(wal_syncer, stop_sender);
         Self {
@@ -128,7 +131,20 @@ impl<C: Ctx, D: DagConsensus> NetworkSyncer<C, D> {
         inner: Arc<NetworkSyncerInner<C, D>>,
         block_fetcher: Arc<BlockFetcher<C>>,
         metrics: Arc<Metrics>,
+        startup_commits: Vec<CommittedSubDag>,
+        commit_consumer: Option<mpsc::Sender<CommittedSubDag>>,
     ) {
+        // The startup proposal runs on the raw syncer before the dispatcher exists, so its
+        // recovery-time commits are forwarded here instead. The consumer channel closes only
+        // once both this sender clone and the dispatcher's are dropped (after shutdown).
+        if let Some(consumer) = &commit_consumer {
+            for subdag in startup_commits {
+                if consumer.send(subdag).await.is_err() {
+                    break;
+                }
+            }
+        }
+
         let mut connections: HashMap<usize, C::JoinHandle<Option<()>>> = HashMap::new();
         let round_timeout_task = C::spawn(Self::round_timeout_task(inner.clone()));
         let cleanup_task = C::spawn(Self::cleanup_task(inner.clone()));

--- a/crates/dag/src/sync/network.rs
+++ b/crates/dag/src/sync/network.rs
@@ -487,7 +487,7 @@ mod test {
             .authorities()
             .map(|_| Metrics::new_for_test(committee.len()))
             .collect();
-        let (networks, addresses) = networks_and_addresses(&metrics).await;
+        let (networks, addresses) = networks_and_addresses(&metrics, 5001).await;
         for (mut network, address) in networks.into_iter().zip(addresses.iter()) {
             let mut waiting_peers: HashSet<_> = HashSet::from_iter(addresses.iter().copied());
             waiting_peers.remove(address);

--- a/crates/dag/src/test_util.rs
+++ b/crates/dag/src/test_util.rs
@@ -26,10 +26,15 @@ pub fn committee(n: usize) -> Arc<Committee> {
     Committee::new_test(vec![1; n])
 }
 
-pub async fn networks_and_addresses(metrics: &[Arc<Metrics>]) -> (Vec<Network>, Vec<SocketAddr>) {
+/// Tests running in parallel bind real sockets: each caller must pass a distinct
+/// `base_port`.
+pub async fn networks_and_addresses(
+    metrics: &[Arc<Metrics>],
+    base_port: u16,
+) -> (Vec<Network>, Vec<SocketAddr>) {
     let host = Ipv4Addr::LOCALHOST;
     let addresses: Vec<_> = (0..metrics.len())
-        .map(|i| SocketAddr::V4(SocketAddrV4::new(host, 5001 + i as u16)))
+        .map(|i| SocketAddr::V4(SocketAddrV4::new(host, base_port + i as u16)))
         .collect();
     let networks =
         addresses

--- a/crates/replica/src/builder.rs
+++ b/crates/replica/src/builder.rs
@@ -4,7 +4,10 @@
 use std::{path::PathBuf, sync::Arc};
 
 use ::prometheus::Registry;
-use dag::{authority::Authority, metrics::Metrics, sync::network::Network};
+use dag::{
+    authority::Authority, consensus::CommittedSubDag, metrics::Metrics, sync::network::Network,
+};
+use tokio::sync::mpsc;
 
 use crate::{
     config::{PrivateReplicaConfig, PublicReplicaConfig},
@@ -30,6 +33,7 @@ pub struct ReplicaBuilder {
     metrics: Option<Arc<Metrics>>,
     network: Option<Network>,
     registry: Registry,
+    commit_consumer: Option<mpsc::Sender<CommittedSubDag>>,
 }
 
 impl ReplicaBuilder {
@@ -48,6 +52,7 @@ impl ReplicaBuilder {
             metrics: None,
             network: None,
             registry: Registry::new(),
+            commit_consumer: None,
         }
     }
 
@@ -85,6 +90,15 @@ impl ReplicaBuilder {
         self
     }
 
+    /// Stream every committed sub-dag, in commit order, into `sender` once it is durably
+    /// written to the WAL. The channel must be bounded: a slow receiver throttles the whole
+    /// replica rather than dropping or reordering commits. On restart, commits recovered
+    /// from the WAL are not re-emitted; catch up via `Storage::iter_commits` first.
+    pub fn with_commit_consumer(mut self, sender: mpsc::Sender<CommittedSubDag>) -> Self {
+        self.commit_consumer = Some(sender);
+        self
+    }
+
     /// Finalize configuration. The returned [`Replica`] holds the
     /// same intent; no tokio work has happened yet.
     pub fn build(self) -> Replica {
@@ -97,6 +111,7 @@ impl ReplicaBuilder {
             metrics: self.metrics,
             network: self.network,
             registry: self.registry,
+            commit_consumer: self.commit_consumer,
         }
     }
 }

--- a/crates/replica/src/replica.rs
+++ b/crates/replica/src/replica.rs
@@ -11,6 +11,7 @@ use consensus::committer::Committer;
 use dag::{
     authority::Authority,
     block::transaction::Transaction,
+    consensus::CommittedSubDag,
     context::Ctx,
     core::{
         Core,
@@ -23,6 +24,7 @@ use dag::{
     sync::{net_sync::NetworkSyncer, network::Network},
 };
 use eyre::{Context, Result, eyre};
+use tokio::sync::mpsc;
 
 use crate::{
     builder::StorageKind,
@@ -44,6 +46,7 @@ pub struct Replica {
     pub(crate) metrics: Option<Arc<Metrics>>,
     pub(crate) network: Option<Network>,
     pub(crate) registry: Registry,
+    pub(crate) commit_consumer: Option<mpsc::Sender<CommittedSubDag>>,
 }
 
 impl Replica {
@@ -61,6 +64,7 @@ impl Replica {
             metrics: metrics_override,
             network: network_override,
             registry,
+            commit_consumer,
         } = self;
 
         let committee = public_config.committee();
@@ -133,6 +137,7 @@ impl Replica {
             enable_synchronizer,
             commit_handler,
             metrics.clone(),
+            commit_consumer,
         );
 
         Ok(ReplicaHandle {

--- a/crates/replica/tests/sync.rs
+++ b/crates/replica/tests/sync.rs
@@ -78,7 +78,7 @@ async fn test_network_sync_with_commit_consumer() {
     }
 
     let mut received = vec![vec![]; receivers.len()];
-    tokio::time::timeout(Duration::from_secs(10), async {
+    tokio::time::timeout(Duration::from_secs(30), async {
         for (receiver, anchors) in receivers.iter_mut().zip(received.iter_mut()) {
             while anchors.len() < MIN_COMMITS {
                 anchors.push(receiver.recv().await.expect("channel closed early").anchor);

--- a/crates/replica/tests/sync.rs
+++ b/crates/replica/tests/sync.rs
@@ -13,12 +13,13 @@ use dag::{
     sync::net_sync::NetworkSyncer,
     test_util::{check_commits, networks_and_addresses},
 };
+use tokio::sync::mpsc;
 
 #[tokio::test]
 async fn test_network_sync() {
     let (_committee, cores) = committee_and_cores::<TokioCtx>(4);
     let metrics: Vec<_> = cores.iter().map(|c| c.metrics.clone()).collect();
-    let (networks, _) = networks_and_addresses(&metrics).await;
+    let (networks, _) = networks_and_addresses(&metrics, 5101).await;
     let mut network_syncers = vec![];
     for (network, core) in networks.into_iter().zip(cores.into_iter()) {
         let commit_handler = CommitHandler::new(
@@ -32,6 +33,7 @@ async fn test_network_sync() {
             false,
             commit_handler,
             Metrics::new_for_test(0),
+            None,
         );
         network_syncers.push(network_syncer);
     }
@@ -44,5 +46,59 @@ async fn test_network_sync() {
         syncers.push(syncer);
     }
 
+    check_commits(&syncers);
+}
+
+/// Every consumer must receive exactly the anchors its replica committed, in commit order.
+#[tokio::test]
+async fn test_network_sync_with_commit_consumer() {
+    const MIN_COMMITS: usize = 10;
+    let (_committee, cores) = committee_and_cores::<TokioCtx>(4);
+    let metrics: Vec<_> = cores.iter().map(|c| c.metrics.clone()).collect();
+    let (networks, _) = networks_and_addresses(&metrics, 5201).await;
+    let mut network_syncers = vec![];
+    let mut receivers = vec![];
+    for (network, core) in networks.into_iter().zip(cores.into_iter()) {
+        let commit_handler = CommitHandler::new(
+            core.block_handler().transaction_time.clone(),
+            Metrics::new_for_test(0),
+        );
+        let (sender, receiver) = mpsc::channel(1024);
+        receivers.push(receiver);
+        let network_syncer = NetworkSyncer::start(
+            network,
+            core,
+            Duration::from_secs(1),
+            false,
+            commit_handler,
+            Metrics::new_for_test(0),
+            Some(sender),
+        );
+        network_syncers.push(network_syncer);
+    }
+
+    let mut received = vec![vec![]; receivers.len()];
+    tokio::time::timeout(Duration::from_secs(10), async {
+        for (receiver, anchors) in receivers.iter_mut().zip(received.iter_mut()) {
+            while anchors.len() < MIN_COMMITS {
+                anchors.push(receiver.recv().await.expect("channel closed early").anchor);
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for commits");
+
+    let mut syncers = vec![];
+    for network_syncer in network_syncers {
+        syncers.push(network_syncer.shutdown().await);
+    }
+
+    // Shutdown dropped the senders; draining yields the complete forwarded sequence.
+    for ((mut receiver, mut anchors), syncer) in receivers.into_iter().zip(received).zip(&syncers) {
+        while let Some(subdag) = receiver.recv().await {
+            anchors.push(subdag.anchor);
+        }
+        assert_eq!(anchors, syncer.commit_handler().committed_leaders());
+    }
     check_commits(&syncers);
 }

--- a/crates/simulator/Cargo.toml
+++ b/crates/simulator/Cargo.toml
@@ -17,7 +17,6 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true }
-parking_lot = { workspace = true }
 
 [dev-dependencies]
 indoc = { workspace = true }

--- a/crates/simulator/src/context.rs
+++ b/crates/simulator/src/context.rs
@@ -8,7 +8,7 @@ use tokio::sync::{mpsc, oneshot};
 
 use super::event_simulator::{Scheduler, simulator_time};
 use super::executor::{ExecutorStateEvent, JoinError, JoinHandle, Sleep, simulator_spawn};
-use dag::consensus::DagConsensus;
+use dag::consensus::{CommittedSubDag, DagConsensus};
 use dag::context::Ctx;
 use dag::core::syncer::Syncer;
 use dag::storage::WalSyncer;
@@ -120,8 +120,11 @@ impl Ctx for SimulatorContext {
 
     type Dispatcher<D: DagConsensus> = InlineDispatcher<D>;
 
-    fn create_dispatcher<D: DagConsensus>(syncer: Syncer<Self, D>) -> Self::Dispatcher<D> {
-        InlineDispatcher::new(syncer)
+    fn create_dispatcher<D: DagConsensus>(
+        syncer: Syncer<Self, D>,
+        commit_consumer: Option<mpsc::Sender<CommittedSubDag>>,
+    ) -> Self::Dispatcher<D> {
+        InlineDispatcher::new(syncer, commit_consumer)
     }
 
     fn start_wal_syncer(_wal_syncer: WalSyncer, _stop: mpsc::Sender<()>) -> oneshot::Receiver<()> {

--- a/crates/simulator/src/dispatcher.rs
+++ b/crates/simulator/src/dispatcher.rs
@@ -3,12 +3,12 @@
 
 use std::collections::HashSet;
 
-use parking_lot::Mutex;
+use tokio::sync::{Mutex, mpsc};
 
 use dag::{
     authority::Authority,
     block::{Block, BlockReference, RoundNumber},
-    consensus::DagConsensus,
+    consensus::{CommittedSubDag, DagConsensus},
     core::{core_thread::CoreDispatch, syncer::Syncer},
     data::Data,
 };
@@ -17,32 +17,56 @@ use crate::context::SimulatorContext;
 
 pub struct InlineDispatcher<D: DagConsensus> {
     syncer: Mutex<Syncer<SimulatorContext, D>>,
+    commit_consumer: Option<mpsc::Sender<CommittedSubDag>>,
 }
 
 impl<D: DagConsensus> InlineDispatcher<D> {
-    pub fn new(syncer: Syncer<SimulatorContext, D>) -> Self {
+    pub fn new(
+        syncer: Syncer<SimulatorContext, D>,
+        commit_consumer: Option<mpsc::Sender<CommittedSubDag>>,
+    ) -> Self {
         Self {
             syncer: Mutex::new(syncer),
+            commit_consumer,
+        }
+    }
+
+    /// Forward newly committed sub-dags to the consumer. Awaited while the caller still
+    /// holds the syncer lock, so the consumer observes commits in commit order and a full
+    /// consumer suspends the producing task (backpressure).
+    async fn forward_commits(&self, committed: Vec<CommittedSubDag>) {
+        let Some(consumer) = &self.commit_consumer else {
+            return;
+        };
+        for subdag in committed {
+            if consumer.send(subdag).await.is_err() {
+                return;
+            }
         }
     }
 }
 
 impl<D: DagConsensus> CoreDispatch<SimulatorContext, D> for InlineDispatcher<D> {
     async fn add_blocks(&self, blocks: Vec<Data<Block>>) {
-        self.syncer.lock().add_blocks(blocks);
+        let mut syncer = self.syncer.lock().await;
+        let committed = syncer.add_blocks(blocks);
+        self.forward_commits(committed).await;
     }
 
     async fn force_new_block(&self, round: RoundNumber) {
-        self.syncer.lock().force_new_block(round);
+        let mut syncer = self.syncer.lock().await;
+        let committed = syncer.force_new_block(round);
+        self.forward_commits(committed).await;
     }
 
     async fn cleanup(&self) {
-        self.syncer.lock().core().cleanup();
+        self.syncer.lock().await.core().cleanup();
     }
 
     async fn get_missing_blocks(&self) -> Vec<HashSet<BlockReference>> {
         self.syncer
             .lock()
+            .await
             .core()
             .block_manager()
             .missing_blocks()
@@ -50,7 +74,7 @@ impl<D: DagConsensus> CoreDispatch<SimulatorContext, D> for InlineDispatcher<D> 
     }
 
     async fn authority_connection(&self, authority: Authority, connected: bool) {
-        let mut lock = self.syncer.lock();
+        let mut lock = self.syncer.lock().await;
         if connected {
             lock.connect_authority(authority);
         } else {


### PR DESCRIPTION
Phase 2 of #208, stacked on #211 (will retarget to `main` once #211 merges).

- `ReplicaBuilder::with_commit_consumer(bounded mpsc::Sender<CommittedSubDag>)`: every committed sub-dag is emitted in commit order, strictly after its WAL write. No consumer → strictly inert (a `Vec` move — usually empty, no allocation — plus one always-false branch).
- `Syncer::add_blocks`/`force_new_block` return the committed sub-dags (previously dropped after the WAL write; `force_new_block`'s old `bool` return was verified dead at all three call sites). Core and syncer stay fully synchronous — no queue.
- The dispatchers own the send, since `CoreDispatch` already serializes syncer access per execution context: the core thread forwards via `blocking_send` **before acking the caller's oneshot** (consumer full → core thread blocks → 32-slot command channel backs up → whole replica throttles); the simulator's `InlineDispatcher` forwards via an awaited send while holding the syncer lock (`parking_lot::Mutex` → `tokio::sync::Mutex`).
- Startup-recovery commits (`force_new_block(0)` runs on the raw syncer before the dispatcher exists) are forwarded at the top of `NetworkSyncer::run`, before any commit-producing task spawns.
- Recovery contract: commits recovered from the WAL are never re-emitted; embedders catch up via `Storage::iter_commits`.
- New metric series `utilization{scope="CoreThread::forward_commits"}` exposes time the core thread spends blocked on a slow consumer.
- Test: `test_network_sync_with_commit_consumer` asserts the received anchor sequence exactly equals `committed_leaders()`, using the consumer stream itself as the progress signal (no fixed sleeps). Test-only: `networks_and_addresses` gains a `base_port` to fix a latent parallel-test port collision.

Refactor-guardian audited the diff: inert on the no-consumer path (no clones, symmetric allocations, no metric/WAL/ordering changes), ordered/complete/deadlock-free with a consumer, simulator None-path event schedule unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)