### PR TITLE
test(replica,simulator): end-to-end #208 contract tests and docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3328,6 +3328,7 @@ dependencies = [
  "minibytes",
  "prometheus",
  "rand 0.8.5",
+ "replica",
  "reqwest",
  "serde",
  "serde_yaml",

--- a/crates/dag/src/consensus.rs
+++ b/crates/dag/src/consensus.rs
@@ -135,6 +135,16 @@ impl CommittedSubDag {
     pub fn sort(&mut self) {
         self.blocks.sort_by_key(|x| x.round());
     }
+
+    /// Number of transactions produced by `Transaction::new_for_test` in this sub-dag.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn count_test_transactions(&self) -> usize {
+        self.blocks
+            .iter()
+            .flat_map(|block| block.transactions())
+            .filter(|transaction| transaction.has_test_marker())
+            .count()
+    }
 }
 
 impl fmt::Debug for CommittedSubDag {

--- a/crates/replica/Cargo.toml
+++ b/crates/replica/Cargo.toml
@@ -23,6 +23,10 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 dag = { workspace = true, features = ["test-utils"] }
+replica = { path = ".", features = ["test-utils"] }
 reqwest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
+
+[features]
+test-utils = ["dag/test-utils"]

--- a/crates/replica/src/replica.rs
+++ b/crates/replica/src/replica.rs
@@ -150,6 +150,45 @@ impl Replica {
     }
 }
 
+#[cfg(any(test, feature = "test-utils"))]
+impl Replica {
+    /// A local committee with ephemeral storage and per-replica test metrics; the commit
+    /// consumer, if any, is attached to replica 0. Nothing is started: run each replica
+    /// via [`Replica::run`]. Concurrent tests must pass distinct `port_offset`s.
+    pub fn new_committee_for_test(
+        committee_size: usize,
+        port_offset: u16,
+        mut commit_consumer: Option<mpsc::Sender<CommittedSubDag>>,
+    ) -> (Vec<Self>, Vec<Arc<Metrics>>) {
+        let public_config =
+            PublicReplicaConfig::new_for_tests(committee_size).with_port_offset(port_offset);
+        // Storage is ephemeral, so the WAL path in the private configs is unused.
+        let private_configs = PrivateReplicaConfig::new_for_benchmarks(
+            &std::path::PathBuf::from("test"),
+            committee_size,
+        );
+
+        let mut replicas = Vec::with_capacity(committee_size);
+        let mut metrics = Vec::with_capacity(committee_size);
+        for (i, private_config) in private_configs.into_iter().enumerate() {
+            let replica_metrics = Metrics::new_for_test(committee_size);
+            metrics.push(replica_metrics.clone());
+            let mut builder = crate::builder::ReplicaBuilder::new(
+                Authority::from(i),
+                public_config.clone(),
+                private_config,
+            )
+            .with_storage(StorageKind::Ephemeral)
+            .with_metrics(replica_metrics);
+            if let Some(commit_consumer) = commit_consumer.take() {
+                builder = builder.with_commit_consumer(commit_consumer);
+            }
+            replicas.push(builder.build());
+        }
+        (replicas, metrics)
+    }
+}
+
 /// A running replica. Generic over the execution context.
 pub struct ReplicaHandle<C: Ctx> {
     authority: Authority,

--- a/crates/replica/tests/commit_consumer.rs
+++ b/crates/replica/tests/commit_consumer.rs
@@ -1,0 +1,140 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Port offsets across test binaries: smoke.rs uses 0/100/200, this file uses 400/500.
+
+use std::{sync::Arc, time::Duration};
+
+use tokio::{sync::mpsc, time};
+
+use dag::{
+    block::{BlockReference, transaction::Transaction},
+    context::TokioCtx,
+    metrics::Metrics,
+};
+use replica::{
+    config::LoadGeneratorConfig,
+    replica::{Replica, ReplicaHandle},
+};
+
+async fn run_all(replicas: Vec<Replica>) -> Vec<ReplicaHandle<TokioCtx>> {
+    let mut handles = Vec::with_capacity(replicas.len());
+    for replica in replicas {
+        handles.push(replica.run().await.expect("test replica must start"));
+    }
+    handles
+}
+
+async fn committed_leaders(metrics: &Arc<Metrics>) -> u64 {
+    metrics.collect().total_committed_leaders()
+}
+
+/// Wait until `metrics` reports at least `target` committed leaders.
+async fn await_commits(metrics: &Arc<Metrics>, target: u64) {
+    while committed_leaders(metrics).await < target {
+        time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+/// Transactions submitted through clients on two different replicas must all come back,
+/// in commit order, through the consumer attached to replica 0.
+#[tokio::test]
+async fn submit_to_commit_round_trip() {
+    const BATCHES_PER_CLIENT: usize = 5;
+    let (sender, mut receiver) = mpsc::channel(1024);
+    let (replicas, _metrics) = Replica::new_committee_for_test(4, 400, Some(sender));
+    let mut handles = run_all(replicas).await;
+
+    for client in [
+        handles[0].transaction_client(),
+        handles[1].transaction_client(),
+    ] {
+        for _ in 0..BATCHES_PER_CLIENT {
+            client
+                .submit(vec![Transaction::new_for_test()])
+                .await
+                .unwrap();
+        }
+    }
+
+    // Receive sub-dags until every submitted transaction has been observed.
+    let mut anchors: Vec<BlockReference> = vec![];
+    let mut observed_transactions = 0;
+    time::timeout(Duration::from_secs(30), async {
+        while observed_transactions < 2 * BATCHES_PER_CLIENT {
+            let subdag = receiver.recv().await.expect("channel closed early");
+            observed_transactions += subdag.count_test_transactions();
+            anchors.push(subdag.anchor);
+        }
+    })
+    .await
+    .expect("timed out waiting for submitted transactions to commit");
+
+    // After shutdown the drained stream must equal the persisted commit sequence exactly.
+    let storage = handles.remove(0).shutdown().await.into_storage();
+    while let Some(subdag) = receiver.recv().await {
+        anchors.push(subdag.anchor);
+    }
+    let persisted: Vec<BlockReference> =
+        storage.iter_commits().map(|commit| commit.leader).collect();
+    assert_eq!(anchors, persisted);
+}
+
+/// A full capacity-1 consumer must freeze replica 0 (backpressure) without deadlocking it:
+/// once drained, the replica catches up and its stream still matches storage.
+#[tokio::test]
+async fn slow_consumer_throttles_replica_without_deadlock() {
+    // The committee's own progress defines the observation windows; no fixed settle sleeps.
+    const WINDOW: u64 = 5;
+    let (sender, mut receiver) = mpsc::channel(1);
+    let (replicas, metrics) = Replica::new_committee_for_test(4, 500, Some(sender));
+    let mut handles = run_all(replicas).await;
+    for handle in &mut handles {
+        // Detach: the generator runs until the replica shuts down.
+        drop(handle.start_load_generator(LoadGeneratorConfig::default()));
+    }
+
+    // Stage 1: the pipeline is live.
+    let first = time::timeout(Duration::from_secs(15), receiver.recv())
+        .await
+        .expect("timed out waiting for the first commit")
+        .expect("channel closed early");
+
+    // Stage 2: with the channel full and undrained, the core thread blocks in blocking_send.
+    // Replica 0 is wedged once its committed count stands still while the others advance.
+    let mut frozen = committed_leaders(&metrics[0]).await;
+    time::timeout(Duration::from_secs(30), async {
+        loop {
+            let others = committed_leaders(&metrics[1]).await;
+            await_commits(&metrics[1], others + WINDOW).await;
+            let current = committed_leaders(&metrics[0]).await;
+            if current == frozen {
+                break;
+            }
+            frozen = current;
+        }
+    })
+    .await
+    .expect("replica 0 was never throttled by the full consumer");
+
+    // Stage 3: draining un-wedges the replica; no deadlock.
+    let drain = tokio::spawn(async move {
+        let mut anchors = vec![first.anchor];
+        while let Some(subdag) = receiver.recv().await {
+            anchors.push(subdag.anchor);
+        }
+        anchors
+    });
+    time::timeout(
+        Duration::from_secs(20),
+        await_commits(&metrics[0], frozen + WINDOW),
+    )
+    .await
+    .expect("replica 0 did not catch up after the consumer drained");
+
+    let storage = handles.remove(0).shutdown().await.into_storage();
+    let anchors = drain.await.unwrap();
+    let persisted: Vec<BlockReference> =
+        storage.iter_commits().map(|commit| commit.leader).collect();
+    assert_eq!(anchors, persisted);
+}

--- a/crates/simulator/src/runner.rs
+++ b/crates/simulator/src/runner.rs
@@ -12,6 +12,7 @@ use consensus::committer::Committer;
 use dag::{
     authority::Authority,
     config::{ConfigError, ImportExport},
+    consensus::CommittedSubDag,
     context::Ctx,
     core::syncer::Syncer,
     metrics::Metrics,
@@ -24,6 +25,7 @@ use replica::{
     replica::ReplicaHandle,
     result::{RunKind, RunResult},
 };
+use tokio::sync::mpsc;
 
 use crate::{
     config::{NetworkTopology, SimulationConfig},
@@ -84,21 +86,34 @@ impl SimulatedNetwork {
     pub async fn new_for_test(
         committee_size: usize,
     ) -> (Self, Vec<ReplicaHandle<SimulatorContext>>) {
-        let public_config = PublicReplicaConfig::new_for_tests(committee_size);
+        Self::new_for_test_with_commit_consumers(vec![None; committee_size]).await
+    }
+
+    /// Like [`SimulatedNetwork::new_for_test`], with one optional commit consumer per
+    /// replica.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub async fn new_for_test_with_commit_consumers(
+        commit_consumers: Vec<Option<mpsc::Sender<CommittedSubDag>>>,
+    ) -> (Self, Vec<ReplicaHandle<SimulatorContext>>) {
+        let public_config = PublicReplicaConfig::new_for_tests(commit_consumers.len());
         let latency_range = Duration::from_millis(50)..Duration::from_millis(100);
         let (network, replicas, _) =
-            SimulationState::build_replicas(public_config, latency_range, None).await;
+            SimulationState::build_replicas(public_config, latency_range, None, commit_consumers)
+                .await;
         network.connect_all().await;
         (network, replicas)
     }
 }
 
 impl SimulationState {
-    /// Build a committee of simulated replicas wired through a [`SimulatedNetwork`].
+    /// Build a committee of simulated replicas wired through a [`SimulatedNetwork`]. The
+    /// committee is derived from `public_config`; `commit_consumers` holds one optional
+    /// consumer per replica.
     async fn build_replicas(
         public_config: PublicReplicaConfig,
         latency_range: Range<Duration>,
         load_generator: Option<LoadGeneratorConfig>,
+        commit_consumers: Vec<Option<mpsc::Sender<CommittedSubDag>>>,
     ) -> (
         SimulatedNetwork,
         Vec<ReplicaHandle<SimulatorContext>>,
@@ -106,6 +121,7 @@ impl SimulationState {
     ) {
         let committee = public_config.committee();
         let committee_size = committee.len();
+        assert_eq!(commit_consumers.len(), committee_size);
         let (network, networks) = SimulatedNetwork::new(&committee, latency_range);
 
         // The simulator doesn't touch disk; the WAL path in the private
@@ -115,16 +131,23 @@ impl SimulationState {
 
         let mut replicas = Vec::with_capacity(committee_size);
         let mut load_generators = Vec::new();
-        for (i, (node_network, private_config)) in
-            networks.into_iter().zip(private_configs).enumerate()
+        for (i, ((node_network, private_config), commit_consumer)) in networks
+            .into_iter()
+            .zip(private_configs)
+            .zip(commit_consumers)
+            .enumerate()
         {
             let authority = Authority::from(i);
             let metrics = Metrics::new_for_test(committee_size);
-            let mut handle = ReplicaBuilder::new(authority, public_config.clone(), private_config)
+            let mut builder = ReplicaBuilder::new(authority, public_config.clone(), private_config)
                 .with_storage(StorageKind::Ephemeral)
                 .with_crypto_disabled()
                 .with_metrics(metrics)
-                .with_network(node_network)
+                .with_network(node_network);
+            if let Some(commit_consumer) = commit_consumer {
+                builder = builder.with_commit_consumer(commit_consumer);
+            }
+            let mut handle = builder
                 .build()
                 .run::<SimulatorContext>()
                 .await
@@ -140,10 +163,12 @@ impl SimulationState {
     async fn setup(config: SimulationConfig) -> Self {
         let public_config = PublicReplicaConfig::new_for_tests(config.committee_size)
             .with_parameters(config.replica_parameters.clone());
+        let commit_consumers = vec![None; config.committee_size];
         let (network, replicas, load_generators) = Self::build_replicas(
             public_config,
             config.latency_range(),
             config.load_generator.clone(),
+            commit_consumers,
         )
         .await;
 

--- a/crates/simulator/tests/commit_consumer.rs
+++ b/crates/simulator/tests/commit_consumer.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use futures::future::join_all;
+use rand::{SeedableRng, rngs::StdRng};
+
+use dag::{
+    block::{BlockReference, transaction::Transaction},
+    consensus::CommittedSubDag,
+    context::Ctx,
+};
+use replica::replica::ReplicaHandle;
+use simulator::{SimulatedNetwork, SimulatorContext, SimulatorExecutor};
+use tokio::sync::mpsc;
+
+/// One committed sub-dag as observed by a consumer: the anchor and its block references.
+type ObservedCommit = (BlockReference, Vec<BlockReference>);
+
+/// Run a committee with a consumer and a submitter task per replica; return each replica's
+/// consumer-observed commit sequence, after asserting it matches that replica's storage.
+fn run_once(seed: u64, committee_size: usize) -> Vec<Vec<ObservedCommit>> {
+    let rng = StdRng::seed_from_u64(seed);
+    SimulatorExecutor::run(rng, async move {
+        let mut senders = Vec::with_capacity(committee_size);
+        let mut collectors = Vec::with_capacity(committee_size);
+        for _ in 0..committee_size {
+            let (sender, mut receiver) = mpsc::channel::<CommittedSubDag>(1024);
+            senders.push(Some(sender));
+            collectors.push(SimulatorContext::spawn(async move {
+                let mut observed: Vec<ObservedCommit> = vec![];
+                while let Some(subdag) = receiver.recv().await {
+                    let references: Vec<BlockReference> = subdag
+                        .blocks
+                        .iter()
+                        .map(|block| *block.reference())
+                        .collect();
+                    observed.push((subdag.anchor, references));
+                }
+                observed
+            }));
+        }
+
+        let (_network, replicas) =
+            SimulatedNetwork::new_for_test_with_commit_consumers(senders).await;
+        let submitters: Vec<_> = replicas
+            .iter()
+            .map(|handle| {
+                let client = handle.transaction_client();
+                SimulatorContext::spawn(async move {
+                    while client
+                        .submit(vec![Transaction::new_for_test()])
+                        .await
+                        .is_ok()
+                    {
+                        SimulatorContext::sleep(Duration::from_millis(100)).await;
+                    }
+                })
+            })
+            .collect();
+
+        SimulatorContext::sleep(Duration::from_secs(30)).await;
+        for submitter in &submitters {
+            SimulatorContext::abort(submitter);
+        }
+
+        let syncers = join_all(replicas.into_iter().map(ReplicaHandle::shutdown)).await;
+        let mut sequences = Vec::with_capacity(committee_size);
+        for (collector, syncer) in collectors.into_iter().zip(syncers) {
+            let observed = collector.await.expect("collector task failed");
+            let storage = syncer.into_storage();
+            let persisted: Vec<ObservedCommit> = storage
+                .iter_commits()
+                .map(|commit| (commit.leader, commit.sub_dag))
+                .collect();
+            assert_eq!(observed, persisted, "consumer stream must match the WAL");
+            assert!(!observed.is_empty(), "expected at least one commit");
+            sequences.push(observed);
+        }
+        sequences
+    })
+}
+
+/// Identical seeds must yield identical consumer-observed commit sequences.
+#[test]
+fn commit_stream_is_deterministic_per_seed() {
+    for seed in [7, 42] {
+        let first = run_once(seed, 4);
+        let second = run_once(seed, 4);
+        assert_eq!(
+            first, second,
+            "seed {seed} produced diverging commit streams"
+        );
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,6 +94,10 @@ Inside that thread, `CoreThread::run` is a `blocking_recv()` loop over an mpsc c
   proposal.
 - **`ForceNewBlock(round)`** — sent by the round-timeout task when the timer fires. The core
   produces a proposal even without a complete quorum.
+
+Both commit-producing commands forward any newly committed sub-dags to the optional commit
+consumer (see [Transaction input and commit output](#transaction-input-and-commit-output))
+**before** acking the caller's oneshot; without a consumer this is a no-op.
 - **`Cleanup`** — periodic, trims committed state.
 - **`GetMissing`** — returns the set of references the DAG is waiting for, used to drive block-fetch
   requests.
@@ -144,7 +148,7 @@ storms.
 | **Round-timeout task** | `net_sync.rs` | Sleeps for `round_timeout`. On fire, sends `ForceNewBlock` to the core. Rearmed via a `Notify` whenever the core advances the round. |
 | **Cleanup task** | `net_sync.rs` | Every 10 s, sends a `Cleanup` command to the core. |
 | **Block fetcher** | `BlockFetcher::start` (`synchronizer.rs`) | Queries the core for missing block references and issues `RequestBlocks` to peers likely to have them. |
-| **Load generator** | `TransactionGenerator::start` (`replica/src/generator.rs`) | Optional. Emits synthetic transactions at a configured rate; the first 8 bytes carry a timestamp for latency. |
+| **Load generator** | `TransactionGenerator::start` (`replica/src/generator.rs`) | Optional. Emits synthetic transactions via `TransactionClient`; the first 8 bytes carry a timestamp for latency. |
 | **Metrics server** | Prometheus server, injected via the builder | Exposes a `/metrics` endpoint for each replica. |
 
 ### From tokio to the core, and back
@@ -154,7 +158,23 @@ Any tokio task that needs to mutate consensus state calls an async method on `Sy
 [`core/core_thread.rs`](../crates/dag/src/core/core_thread.rs)). Backpressure is implicit: if the
 core thread is slow, the command channel (capacity 32) fills up, and the calling task's `.await`
 stalls — which propagates naturally to the networking buffers (capacity 16 per connection) and
-ultimately to the TCP socket.
+ultimately to the TCP socket. A configured commit consumer adds one more stage at the front of that
+chain: when its bounded channel is full, the core thread blocks in `blocking_send` (visible as
+`utilization{scope="CoreThread::forward_commits"}`), so a slow external executor throttles the
+whole replica the same way.
+
+### Transaction input and commit output
+
+The replica's external contract is ordered bytes in, ordered bytes out — both executor-agnostic:
+
+- **Input.** `ReplicaHandle::transaction_client()` returns a cloneable `TransactionClient`
+  (`replica/src/client.rs`) wrapping the bounded transaction channel; the built-in load generator
+  submits through the same client. Under the simulator, submitters must run as simulated tasks
+  (spawned via `Ctx::spawn`).
+- **Output.** `ReplicaBuilder::with_commit_consumer` accepts a bounded
+  `mpsc::Sender<CommittedSubDag>`; every committed sub-dag is emitted in commit order, strictly
+  after its WAL write. On restart, commits recovered from the WAL are **not** re-emitted —
+  embedders catch up by reading `Storage::iter_commits` before subscribing to new commits.
 
 ## Storage: the Custom WAL
 

--- a/docs/simulator.md
+++ b/docs/simulator.md
@@ -144,3 +144,13 @@ fn one_down_stays_consistent() {
 configuration with the CLI. The committed sub-DAGs stay available through the returned storages —
 that is how the CLI's `--export-dag` flag produces `dag.ndjson` after the run. Because every run is
 deterministic in the `rng_seed`, these tests are reproducible across machines.
+
+For finer control than `SimulationRunner` offers — external transaction submission via
+`TransactionClient` and live commit streaming via `ReplicaBuilder::with_commit_consumer` —
+tests can build the committee directly with `SimulatedNetwork::new_for_test` (or
+`new_for_test_with_commit_consumers`), as
+[`crates/simulator/tests/commit_consumer.rs`](../crates/simulator/tests/commit_consumer.rs) does.
+One rule applies: **any task that awaits replica channels (submitters, commit collectors) must run
+inside the simulated world**, spawned via `SimulatorContext::spawn` — awaiting from outside the
+executor deadlocks the run. Determinism extends to the consumer streams: identical seeds yield
+byte-identical commit sequences.


### PR DESCRIPTION
Phase 3 of #208, stacked on #212 (will retarget as the stack merges).

**Tests**
- `submit_to_commit_round_trip` (tokio): transactions submitted through `TransactionClient`s on two different replicas all come back, in commit order, through the consumer on replica 0; after shutdown the drained stream equals the persisted leader sequence exactly.
- `slow_consumer_throttles_replica_without_deadlock` (tokio): a full capacity-1 consumer provably freezes replica 0 (its committed count stands still while the committee advances — observation windows are event-defined by committee progress, not fixed sleeps) and draining un-wedges it with the stream still matching storage.
- `commit_stream_is_deterministic_per_seed` (simulator): submitters and collectors run as simulated tasks; identical seeds yield identical consumer-observed commit sequences, each asserted equal to that replica's storage (persist-before-emit).

**Test infrastructure** (test-utils gated): `Replica::new_committee_for_test`, `SimulatedNetwork::new_for_test_with_commit_consumers`, `CommittedSubDag::count_test_transactions`.

**Docs**: `docs/architecture.md` gains a "Transaction input and commit output" section (contract, backpressure chain, no-replay-on-recovery) and `docs/simulator.md` documents programmatic submission/consumption with the spawn-inside-the-simulation rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)