### PR TITLE
chore: bump Rust toolchain to 1.97

### DIFF
--- a/crates/dag/src/storage/state.rs
+++ b/crates/dag/src/storage/state.rs
@@ -57,8 +57,7 @@ impl RecoveredStateBuilder {
     pub(super) fn commit_data(&mut self, commits: Vec<CommitData>) {
         for commit_data in commits {
             self.last_committed_leader = Some(commit_data.leader);
-            self.committed_blocks
-                .extend(commit_data.sub_dag.into_iter());
+            self.committed_blocks.extend(commit_data.sub_dag);
         }
     }
 

--- a/crates/dag/src/sync/net_sync.rs
+++ b/crates/dag/src/sync/net_sync.rs
@@ -169,7 +169,7 @@ impl<C: Ctx, D: DagConsensus> NetworkSyncer<C, D> {
         join_all(
             connections
                 .into_values()
-                .chain([round_timeout_task, cleanup_task].into_iter()),
+                .chain([round_timeout_task, cleanup_task]),
         )
         .await;
         Arc::try_unwrap(block_fetcher)

--- a/crates/dag/src/sync/network.rs
+++ b/crates/dag/src/sync/network.rs
@@ -210,13 +210,10 @@ impl Worker {
                     work = self.connect_and_handle(delay, self.peer).boxed();
                 }
                 Either::Right((received, _work)) => {
-                    if let Some(received) = received {
-                        tracing::debug!("Replaced connection for {}", self.peer_id);
-                        work = self.handle_passive_stream(received).boxed();
-                    } else {
-                        // Channel closed, server is terminated
-                        return None;
-                    }
+                    // A closed channel means the server is terminated
+                    let received = received?;
+                    tracing::debug!("Replaced connection for {}", self.peer_id);
+                    work = self.handle_passive_stream(received).boxed();
                 }
             }
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92"
-components = ["clippy", "rustfmt"]
+channel = "1.97"
+components = ["clippy", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
Bump the pinned toolchain from 1.92 to 1.97 (the current stable series — the channel pin deliberately tracks the latest 1.97.x patch release, currently 1.97.1) and add the `rust-analyzer` component so the IDE extension uses a rust-analyzer matching the pin instead of its bundled (newer) one.

The bump surfaces three new clippy lints in the `dag` crate, fixed here with no behavior change:
- `useless_conversion`: redundant `.into_iter()` in `storage/state.rs` and `sync/net_sync.rs`
- `question_mark`: if-let/else in `sync/network.rs` rewritten with `?` (identical semantics — the function returns `Option`)

Workspace `cargo test` and `clippy --workspace --all-targets` are clean on 1.97.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)