### PR TITLE
fix(lean): conclude liveness on a view a replica can hold

### DIFF
--- a/lean/Hydrozoan/DirectLiveness/Proof.lean
+++ b/lean/Hydrozoan/DirectLiveness/Proof.lean
@@ -6,8 +6,9 @@ import Hydrozoan.Helpers.DirectLiveness
 
 Generated proof layer; not part of the audit surface. Both conjuncts
 are the wave chain of `Helpers/DirectLiveness.lean`; the harvest form
-adds the eventual-view lift and `Decided.directSlow`. `fastLatency` is
-the demoted performance characterization, proven with the same care.
+adds the caught-up-view lift (`slowCommitInView_of_coversUpto`) and
+`Decided.directSlow`. `fastLatency` is the demoted performance
+characterization, proven with the same care.
 -/
 
 namespace Hydrozoan
@@ -20,11 +21,12 @@ variable {Replica BlockId : Type*} [Fintype Replica] [DecidableEq Replica]
 
 theorem holds : Statement := by
   intro Replica BlockId _ _ _ _ _ _ U T R k hT hcard hs hRk hpop0 hpop1 hpop2 hlead
+    V hcov
   obtain ⟨L, hL⟩ := exists_isLeaderBlock_of_populated hpop0 hlead
   have hslow := slowCommit_of_synchronised hcard hs hRk hpop1 hpop2 hL
     (by rw [hL.2.2]; exact hlead)
   exact ⟨L, hL, hslow,
-    Decided.directSlow hL (slowCommitInView_full_of_slowCommit hslow)⟩
+    Decided.directSlow hL (slowCommitInView_of_coversUpto hslow hcov)⟩
 
 theorem fastLatency :
     ∀ (Replica BlockId : Type) [Fintype Replica] [DecidableEq Replica]

--- a/lean/Hydrozoan/DirectLiveness/Statement.lean
+++ b/lean/Hydrozoan/DirectLiveness/Statement.lean
@@ -6,7 +6,9 @@ import Hydrozoan.Model.Decided
 
 A synchronised, populated wave with a correct leader commits. One claim
 forms `Statement`: `CommitLiveness`, concluding both the slow-commit
-threshold and its harvest as a `Decided` verdict at the eventual view.
+threshold and its harvest as a `Decided` verdict on any view caught up
+to the decision round (`View.CoversUpto`) — the eventual view is the
+special case.
 The opportunistic pair (`FastLatency`, `SkipLatency`) is
 **deliberately outside `Statement`**: both are performance
 characterizations — they fire exactly when the actual faults fit the
@@ -31,8 +33,11 @@ variable {Replica BlockId : Type*} [Fintype Replica] [DecidableEq Replica]
 /-- **Commit liveness**: a quorum-sized set of correct replicas,
 populated through the wave's three rounds and synchronised from some
 `R` at or before the wave, commits its correct leader — the slow-commit
-threshold is met, and the decision logic outputs the commit verdict at
-the eventual view (the harvest form the later phases consume).
+threshold is met, and the decision logic outputs the commit verdict on
+any view caught up to the decision round (the harvest form the later
+phases consume). The certificates sit at the decision round, so a
+caught-up view holds them; the eventual view is caught up to every
+horizon.
 
 `SlowCommit` here is a threshold fact, not a route: the fast path may
 also fire in the same universe (the rule predicates are not
@@ -47,9 +52,11 @@ def CommitLiveness (U : BlockUniverse Replica BlockId) : Prop :=
     PopulatedOn U T (S.slotRound k + 1) →  -- ... the voting round ...
     PopulatedOn U T (S.slotRound k + 2) →  -- ... and the decision round,
     S.leader k ∈ T →                     -- and the slot's leader is in T:
-    ∃ L, IsLeaderBlock U k L ∧           -- then a candidate exists,
+    ∀ V : View U,                        -- then, on any view caught up
+      V.CoversUpto (S.slotRound k + 2) → -- ... to the decision round:
+    ∃ L, IsLeaderBlock U k L ∧           -- a candidate exists,
       SlowCommit U L (S.slotRound k) ∧   -- the slow threshold is met,
-      Decided U (View.full U) k (some L)  -- and its verdict is committed
+      Decided U V k (some L)             -- and its verdict is committed
 
 /-- Direct-commit liveness over every fault configuration, schedule,
 tie-break order, and block universe the model admits. -/

--- a/lean/Hydrozoan/EventualDecision/Proof.lean
+++ b/lean/Hydrozoan/EventualDecision/Proof.lean
@@ -18,7 +18,8 @@ theorem holds : Statement := by
 /-- **The ledger does not stall** (the composed corollary): under a fair
 schedule, past every slot `k` and round `R` there is a bound `b` such
 that any universe in which `T` is synchronised and fills the run's span
-has every slot below `b` decided at the eventual view. -/
+has every slot below `b` decided on any view caught up to the run's
+last decision round. -/
 theorem ledgerProgress :
     ∀ (Replica BlockId : Type) [Fintype Replica] [DecidableEq Replica]
       [DecidableEq BlockId] [LinearOrder BlockId] [Faults Replica]
@@ -32,11 +33,12 @@ theorem ledgerProgress :
           SynchronisedOn U T R →
           (∀ r, S.slotRound b ≤ r → r ≤ S.slotRound (b + c - 1) + 2 →
             PopulatedOn U T r) →
-          ∀ i, i < b → ∃ v, Decided U (View.full U) i v := by
+          ∀ V : View U, V.CoversUpto (S.slotRound (b + c - 1) + 2) →
+          ∀ i, i < b → ∃ v, Decided U V i v := by
   intro Replica BlockId _ _ _ _ _ S T R k c hT hcard hc hspan hfair
   obtain ⟨b, hkb, hRb, hlead⟩ := runsRecur Replica T c k R hfair
-  exact ⟨b, hkb, hRb, fun U hsync hpop =>
-    runDecidesBelow U T R b c hT hcard hsync hc hspan hRb hlead hpop⟩
+  exact ⟨b, hkb, hRb, fun U hsync hpop V hcov =>
+    runDecidesBelow U T R b c hT hcard hsync hc hspan hRb hlead hpop V hcov⟩
 
 end EventualDecision
 end Hydrozoan

--- a/lean/Hydrozoan/EventualDecision/Statement.lean
+++ b/lean/Hydrozoan/EventualDecision/Statement.lean
@@ -79,7 +79,9 @@ def RunDecidesBelow (U : BlockUniverse Replica BlockId) : Prop :=
     (∀ r, S.slotRound b ≤ r →            -- and T fills every round from
       r ≤ S.slotRound (b + c - 1) + 2 →  -- the run's propose round to its
       PopulatedOn U T r) →               -- last decision round:
-    ∀ i, i < b → ∃ v, Decided U (View.full U) i v  -- all below decided.
+    ∀ V : View U,                        -- then, on any view caught up
+      V.CoversUpto (S.slotRound (b + c - 1) + 2) →  -- ... to that round:
+    ∀ i, i < b → ∃ v, Decided U V i v    -- all below decided.
 
 /-- Eventual decision, over every fault configuration, schedule,
 tie-break order, and block universe the model admits. -/

--- a/lean/Hydrozoan/Grounding/Statement.lean
+++ b/lean/Hydrozoan/Grounding/Statement.lean
@@ -95,7 +95,10 @@ def HypothesesRealizable : Prop :=
 /-- **Grounded progress.** Under wave-aligned round-robin, the
 composed liveness conclusion is achievable with no premise at all:
 past every point, some universe commits a bound with every slot below
-it decided. An achievability claim — the statement asserts the
+it decided — on any view caught up to the bound's decision round
+(`b + 4 = slotRound (b + 2) + 2` under the wave-aligned schedule; the
+eventual view is caught up to every horizon, so it instantiates the
+claim). An achievability claim — the statement asserts the
 conclusion's satisfiability, not the route to it (a universe may reach
 these verdicts by any rule). Each horizon is witnessed by its own
 finite universe (`U.ids` is a `Finset`, so no single universe decides
@@ -105,10 +108,12 @@ qualify. -/
 def GroundedProgress : Prop :=
   ∀ (n : ℕ) (hn : 0 < n) [Faults (Fin n)],
     ∀ k : ℕ, ∃ b, k ≤ b ∧                     -- past any slot k,
-      ∃ U : BlockUniverse (Fin n) ℕ,          -- some universe commits b
-        (∃ L, Decided (S := waveRobin n hn) U (View.full U) b (some L)) ∧
+      ∃ U : BlockUniverse (Fin n) ℕ,          -- some universe commits b:
+        ∀ V : View U,                         -- on any view caught up to
+          V.CoversUpto (b + 4) →              -- ... the decision round,
+        (∃ L, Decided (S := waveRobin n hn) U V b (some L)) ∧
         ∀ i, i < b → ∃ v,                     -- with every slot below
-          Decided (S := waveRobin n hn) U (View.full U) i v  -- decided.
+          Decided (S := waveRobin n hn) U V i v  -- decided.
 
 /-- Grounding, over every replica count and fault configuration the
 model admits. -/

--- a/lean/Hydrozoan/Helpers/DirectLiveness.lean
+++ b/lean/Hydrozoan/Helpers/DirectLiveness.lean
@@ -121,15 +121,30 @@ theorem certificates_subset_ids {U : BlockUniverse Replica BlockId}
     {L : BlockId} {r : ℕ} : certificates U L r ⊆ U.ids :=
   fun _ hC => (mem_certificates.mp hC).1
 
-/-- A universe-level slow commit is a slow commit at the eventual
-view. -/
-theorem slowCommitInView_full_of_slowCommit
-    {U : BlockUniverse Replica BlockId} {L : BlockId} {r : ℕ}
-    (h : SlowCommit U L r) : SlowCommitInView U (View.full U) L r := by
-  have hinter : certificatesInView U (View.full U) L r
-      = certificates U L r := by
-    simp only [certificatesInView, View.full]
-    exact Finset.inter_eq_left.mpr certificates_subset_ids
+/-- The eventual view is caught up to every horizon. -/
+theorem View.coversUpto_full (U : BlockUniverse Replica BlockId) (N : ℕ) :
+    (View.full U).CoversUpto N :=
+  fun _ hb _ => hb
+
+/-- Caught up to `N` is caught up to every lower horizon. -/
+theorem View.CoversUpto.mono {U : BlockUniverse Replica BlockId}
+    {V : View U} {M N : ℕ}
+    (h : V.CoversUpto N) (hMN : M ≤ N) : V.CoversUpto M :=
+  fun b hb hr => h b hb (le_trans hr hMN)
+
+/-- A view caught up to the decision round holds every certificate, so
+a universe-level slow commit is a slow commit in that view. -/
+theorem slowCommitInView_of_coversUpto
+    {U : BlockUniverse Replica BlockId} {V : View U} {L : BlockId} {r : ℕ}
+    (h : SlowCommit U L r) (hcov : V.CoversUpto (r + 2)) :
+    SlowCommitInView U V L r := by
+  have hsub : certificates U L r ⊆ V.ids := by
+    intro C hC
+    obtain ⟨hCids, hCr, -⟩ := mem_certificates.mp hC
+    exact hcov C hCids (le_of_eq hCr)
+  have hinter : certificatesInView U V L r = certificates U L r := by
+    simp only [certificatesInView]
+    exact Finset.inter_eq_left.mpr hsub
   simp only [SlowCommitInView, certifiersInView, hinter]
   simp only [SlowCommit, certifiers] at h
   exact h

--- a/lean/Hydrozoan/Helpers/EventualDecision.lean
+++ b/lean/Hydrozoan/Helpers/EventualDecision.lean
@@ -35,9 +35,9 @@ schedule monotonicity), and the indirect descent settles every slot
 below the run. -/
 theorem runDecidesBelow (U : BlockUniverse Replica BlockId) :
     RunDecidesBelow U := by
-  intro T R b c hT hcard hsync hc hspan hRb hlead hpop i hi
+  intro T R b c hT hcard hsync hc hspan hRb hlead hpop V hcov i hi
   have hrun : ∀ j, b ≤ j → j ≤ b + c - 1 →
-      ∃ B, Decided U (View.full U) j (some B) := by
+      ∃ B, Decided U V j (some B) := by
     intro j h1 h2
     -- The slot's leader is in T: it is the (j - b)-th slot of the run.
     have hleadj : S.leader j ∈ T := by
@@ -50,7 +50,7 @@ theorem runDecidesBelow (U : BlockUniverse Replica BlockId) :
     obtain ⟨L, -, -, hdec⟩ :=
       DirectLiveness.holds Replica BlockId U T R j hT hcard hsync hRj
         (hpop _ hbj (by omega)) (hpop _ (by omega) (by omega))
-        (hpop _ (by omega) (by omega)) hleadj
+        (hpop _ (by omega) (by omega)) hleadj V (hcov.mono (by omega))
     exact ⟨L, hdec⟩
   exact decided_below_of_committed_run (by omega)
     (fun i' hi' => hspan b i' hi') hrun i hi

--- a/lean/Hydrozoan/Helpers/Grounding.lean
+++ b/lean/Hydrozoan/Helpers/Grounding.lean
@@ -277,15 +277,18 @@ theorem groundedProgress : GroundedProgress := by
   have hleadb : S.leader b ∈ (Correct : Finset (Fin n)) := by
     have := hlead 0 (by omega)
     rwa [Nat.add_zero] at this
+  refine ⟨b, hkb, U, ?_⟩
+  intro V hcov
   obtain ⟨L, -, -, hL⟩ :=
     DirectLiveness.holds (Fin n) ℕ U (Correct : Finset (Fin n)) 0 b
       Finset.Subset.rfl hq hsync (Nat.zero_le _) (hpop b (by omega))
       (hpop (b + 1) (by omega)) (hpop (b + 2) (by omega)) hleadb
+      V (hcov.mono (by change b + 2 ≤ b + 4; omega))
   have hbelow :=
     EventualDecision.runDecidesBelow U (Correct : Finset (Fin n)) 0 b 3
       Finset.Subset.rfl hq hsync (by omega) hspan (Nat.zero_le _) hlead
-      (fun r _ h2 => hpop r h2)
-  exact ⟨b, hkb, U, ⟨L, hL⟩, hbelow⟩
+      (fun r _ h2 => hpop r h2) V (hcov.mono (by change b + 4 ≤ b + 4; omega))
+  exact ⟨⟨L, hL⟩, hbelow⟩
 
 end Progress
 

--- a/lean/Hydrozoan/Model/Liveness.lean
+++ b/lean/Hydrozoan/Model/Liveness.lean
@@ -111,7 +111,7 @@ universe at a round at or below `N`. What a replica that has received
 everything up to `N` holds — and the hypothesis under which a liveness
 result holds of a replica's own view rather than of the eventual view.
 The eventual view satisfies it at every `N`
-(`coversUpto_full`, `Helpers/DirectLiveness.lean`). -/
+(`View.coversUpto_full`, `Helpers/DirectLiveness.lean`). -/
 def View.CoversUpto {U : BlockUniverse Replica BlockId}
     (V : View U) (N : ℕ) : Prop :=
   ∀ b ∈ U.ids, (U.block b).round ≤ N → b ∈ V.ids

--- a/lean/Hydrozoan/Model/Liveness.lean
+++ b/lean/Hydrozoan/Model/Liveness.lean
@@ -100,10 +100,20 @@ abbrev Synchronised (U : BlockUniverse Replica BlockId) (R : ℕ) : Prop :=
 
 /-- Every correct replica's *eventual* view: the whole universe,
 packaged as a `View`. The structural rendering of "eventually every
-correct replica holds everything" — liveness theorems conclude here,
-and decision monotonicity transports any view's verdicts into it.
-Adds no information beyond `U` itself. -/
+correct replica holds everything" — decision monotonicity transports
+any view's verdicts into it, and it discharges every `CoversUpto`
+hypothesis. Adds no information beyond `U` itself. -/
 def View.full (U : BlockUniverse Replica BlockId) : View U :=
   ⟨U.ids, Finset.Subset.rfl, U.complete⟩
+
+/-- **A view caught up to round `N`**: it holds every block of the
+universe at a round at or below `N`. What a replica that has received
+everything up to `N` holds — and the hypothesis under which a liveness
+result holds of a replica's own view rather than of the eventual view.
+The eventual view satisfies it at every `N`
+(`coversUpto_full`, `Helpers/DirectLiveness.lean`). -/
+def View.CoversUpto {U : BlockUniverse Replica BlockId}
+    (V : View U) (N : ℕ) : Prop :=
+  ∀ b ∈ U.ids, (U.block b).round ≤ N → b ∈ V.ids
 
 end Hydrozoan

--- a/lean/HydrozoanTest/DirectLiveness.lean
+++ b/lean/HydrozoanTest/DirectLiveness.lean
@@ -54,6 +54,7 @@ example : ∃ L, IsLeaderBlock U6 0 L ∧ SlowCommit U6 L 0 ∧
   DirectLiveness.holds (Fin 7) (Fin 15) U6 (Correct : Finset (Fin 7)) 0 0
     (by decide) (by decide) u6_synchronised (by decide) (by decide)
     (by decide) (by decide) (by decide)
+    (View.full U6) (View.coversUpto_full U6 _)
 
 -- ## Fast path at low faults (Fin 4, f = 0, c = 1, k = 1)
 

--- a/lean/HydrozoanTest/EventualDecision.lean
+++ b/lean/HydrozoanTest/EventualDecision.lean
@@ -91,7 +91,7 @@ example : ∀ i, i < 2 → ∃ v, Decided U10 (View.full U10) i v :=
     (by intro i hi
         have : i = 0 ∨ i = 1 ∨ i = 2 := by omega
         rcases this with rfl | rfl | rfl <;> decide)
-    u10_populated
+    u10_populated (View.full U10) (View.coversUpto_full U10 _)
 
 -- The same run applied at R = 2 = slotRound b — the exact boundary of
 -- `R ≤ slotRound b`, killing a strengthening to strict inequality
@@ -105,7 +105,7 @@ example : ∀ i, i < 2 → ∃ v, Decided U10 (View.full U10) i v :=
     (by intro i hi
         have : i = 0 ∨ i = 1 ∨ i = 2 := by omega
         rcases this with rfl | rfl | rfl <;> decide)
-    u10_populated
+    u10_populated (View.full U10) (View.coversUpto_full U10 _)
 
 -- A fairness negative: consecutive slots never share a leader, so a
 -- singleton T is starved at c = 2 — FairRunOn is not trivially true.
@@ -146,9 +146,12 @@ example : ∃ b, 5 ≤ b ∧ 3 ≤ Slots.slotRound (Replica := Fin 4) b ∧
       (∀ r, Slots.slotRound (Replica := Fin 4) b ≤ r →
         r ≤ Slots.slotRound (Replica := Fin 4) (b + 3 - 1) + 2 →
         PopulatedOn U (Correct : Finset (Fin 4)) r) →
-      ∀ i, i < b → ∃ v, Decided U (View.full U) i v :=
-  EventualDecision.ledgerProgress (Fin 4) (Fin 24)
-    (Correct : Finset (Fin 4)) 3 5 3
-    (by decide) (by decide) (by omega) spansEligible_four fairRun_four
+      ∀ i, i < b → ∃ v, Decided U (View.full U) i v := by
+  obtain ⟨b, hk, hR, hrest⟩ :=
+    EventualDecision.ledgerProgress (Fin 4) (Fin 24)
+      (Correct : Finset (Fin 4)) 3 5 3
+      (by decide) (by decide) (by omega) spansEligible_four fairRun_four
+  exact ⟨b, hk, hR, fun U hsync hpop =>
+    hrest U hsync hpop (View.full U) (View.coversUpto_full U _)⟩
 
 end HydrozoanTest

--- a/lean/HydrozoanTest/EventualDecision.lean
+++ b/lean/HydrozoanTest/EventualDecision.lean
@@ -15,6 +15,11 @@ schedule leader `k % 4`) on an eight-round table:
   liveness, whose slot-4 wave needs its decision round 6 populated (the
   indirect-liveness descent, by contrast, consumed the commits
   ready-made); round 7 is unconsumed headroom.
+* **The partial view `v10`** (rounds 0–6; round 7 outside):
+  `RunDecidesBelow` applied at it pins the statement's `CoversUpto`
+  horizon — every other application discharges the premise with
+  `coversUpto_full`, which proves *any* horizon, so this is the one
+  guard against a silently raised horizon constant.
 * **`fairRun_four`**: the pipelined schedule is provably fair to the
   correct set at `c = 3` — runs start at every `k' = 4k + 2` — proved
   from the definition, not by finite enumeration.
@@ -92,6 +97,35 @@ example : ∀ i, i < 2 → ∃ v, Decided U10 (View.full U10) i v :=
         have : i = 0 ∨ i = 1 ∨ i = 2 := by omega
         rcases this with rfl | rfl | rfl <;> decide)
     u10_populated (View.full U10) (View.coversUpto_full U10 _)
+
+/-- The partial view of `U10` holding exactly rounds 0–6 — the run's
+last decision round, with round 7 outside. -/
+def v10 : View U10 where
+  ids := Finset.univ.filter fun i => (U10.block i).round ≤ 6
+  subset_ids := Finset.filter_subset _ _
+  complete := by decide
+
+/-- `v10` is caught up to the run's last decision round. -/
+theorem v10_coversUpto : v10.CoversUpto 6 := by
+  show ∀ b ∈ U10.ids, (U10.block b).round ≤ 6 → b ∈ v10.ids
+  decide
+
+-- Genuinely partial: the round-7 block 21 is outside.
+example : ¬ v10.CoversUpto 7 := fun h =>
+  absurd (h 21 (by decide) (by decide)) (by decide)
+
+-- The same run harvested at the partial view — the guard that pins the
+-- statement's horizon at the run's last decision round: a raised
+-- horizon constant leaves `v10` short and fails this application.
+example : ∀ i, i < 2 → ∃ v, Decided U10 v10 i v :=
+  (EventualDecision.holds (Fin 4) (Fin 24)).1 U10
+    (Correct : Finset (Fin 4)) 0 2 3
+    (by decide) (by decide) u10_synchronised (by omega) spansEligible_four
+    (by decide)
+    (by intro i hi
+        have : i = 0 ∨ i = 1 ∨ i = 2 := by omega
+        rcases this with rfl | rfl | rfl <;> decide)
+    u10_populated v10 v10_coversUpto
 
 -- The same run applied at R = 2 = slotRound b — the exact boundary of
 -- `R ≤ slotRound b`, killing a strengthening to strict inequality

--- a/lean/HydrozoanTest/Grounding.lean
+++ b/lean/HydrozoanTest/Grounding.lean
@@ -106,8 +106,9 @@ example : ∃ b, 5 ≤ b ∧ ∃ U : BlockUniverse (Fin 7) ℕ,
     (∃ L, Decided (S := Grounding.waveRobin 7 (by omega)) U
       (View.full U) b (some L)) ∧
     ∀ i, i < b → ∃ v, Decided (S := Grounding.waveRobin 7 (by omega)) U
-      (View.full U) i v :=
-  Grounding.holds.2.2 7 (by omega) 5
+      (View.full U) i v := by
+  obtain ⟨b, hk, U, h⟩ := Grounding.holds.2.2 7 (by omega) 5
+  exact ⟨b, hk, U, h (View.full U) (View.coversUpto_full U _)⟩
 
 -- ... and at the k = 0 boundary, second configuration: even with
 -- nothing below to decide, the commit clause still demands a real
@@ -116,8 +117,9 @@ example : ∃ b, 0 ≤ b ∧ ∃ U : BlockUniverse (Fin 4) ℕ,
     (∃ L, Decided (S := Grounding.waveRobin 4 (by omega)) U
       (View.full U) b (some L)) ∧
     ∀ i, i < b → ∃ v, Decided (S := Grounding.waveRobin 4 (by omega)) U
-      (View.full U) i v :=
-  Grounding.holds.2.2 4 (by omega) 0
+      (View.full U) i v := by
+  obtain ⟨b, hk, U, h⟩ := Grounding.holds.2.2 4 (by omega) 0
+  exact ⟨b, hk, U, h (View.full U) (View.coversUpto_full U _)⟩
 
 /-! ## The pigeonhole contrast: per-slot rotation starves at the bound
 

--- a/lean/HydrozoanTest/LivenessHardening.lean
+++ b/lean/HydrozoanTest/LivenessHardening.lean
@@ -141,6 +141,7 @@ example : ∃ L, IsLeaderBlock U12 0 L ∧ SlowCommit U12 L 0 ∧
     ({1, 2, 3, 4, 5, 6} : Finset (Fin 8)) 0 0
     (by decide) (by decide) u12_synchronised (by decide) (by decide)
     (by decide) (by decide) (by decide)
+    (View.full U12) (View.coversUpto_full U12 _)
 
 -- ## Route diversification (U13, the frozen Fin 7 configuration)
 
@@ -369,5 +370,6 @@ example : ∃ L, IsLeaderBlock U14 1 L ∧ SlowCommit U14 L 3 ∧
   DirectLiveness.holds (Fin 6) (Fin 30) U14 (Correct : Finset (Fin 6)) 0 1
     (by decide) (by decide) u14_synchronised (by decide) (by decide)
     (by decide) (by decide) (by decide)
+    (View.full U14) (View.coversUpto_full U14 _)
 
 end HydrozoanTest

--- a/lean/scripts/check_no_holes.py
+++ b/lean/scripts/check_no_holes.py
@@ -20,6 +20,11 @@ Additionally, every file named `Statement.lean` must be proof-free
 sit outside the audit convention that Statement files are read in full and
 proof files not at all.
 
+Finally, `View.full` may appear in no `Statement.lean` and no `Model/`
+file: a liveness statement concludes on a view a replica can hold
+(gdanezis/lean-dag#12). The `def View.full` site itself is vocabulary,
+not a claim, and is exempt.
+
 This script is part of the trusted base: it is meant to be read once,
 top to bottom, and then believed. Keep it dumb.
 """
@@ -34,6 +39,8 @@ STATEMENT_FORBIDDEN = re.compile(
     r"^\s*(?:(?:private|protected|noncomputable|@\[[^\]]*\])\s+)*"
     r"(theorem|lemma|example|instance)\b"
 )
+FULLVIEW = re.compile(r"\bView\.full\b")
+FULLVIEW_DEF = re.compile(r"^\s*def View\.full\b")
 ROOT = Path(__file__).resolve().parent.parent
 SOURCES = ["Hydrozoan.lean", "HydrozoanTest.lean", "Hydrozoan", "HydrozoanTest"]
 
@@ -85,6 +92,13 @@ def main():
                         f"{path.relative_to(ROOT)}:{lineno}: "
                         f"{match.group(1)} (proof material in a Statement file)"
                     )
+            in_model = "Model" in path.relative_to(ROOT).parts
+            if (path.name == "Statement.lean" or in_model) \
+                    and FULLVIEW.search(code) and not FULLVIEW_DEF.search(code):
+                holes.append(
+                    f"{path.relative_to(ROOT)}:{lineno}: "
+                    "View.full (a liveness statement concludes on a view)"
+                )
     if holes:
         print("Proof holes found:")
         for hole in holes:

--- a/lean/scripts/check_no_holes.py
+++ b/lean/scripts/check_no_holes.py
@@ -40,7 +40,9 @@ STATEMENT_FORBIDDEN = re.compile(
     r"(theorem|lemma|example|instance)\b"
 )
 FULLVIEW = re.compile(r"\bView\.full\b")
-FULLVIEW_DEF = re.compile(r"^\s*def View\.full\b")
+FULLVIEW_DEF = re.compile(
+    r"^\s*(?:(?:private|protected|noncomputable|@\[[^\]]*\])\s+)*def View\.full\b"
+)
 ROOT = Path(__file__).resolve().parent.parent
 SOURCES = ["Hydrozoan.lean", "HydrozoanTest.lean", "Hydrozoan", "HydrozoanTest"]
 


### PR DESCRIPTION
Ports item D of [gdanezis/lean-dag#12](https://github.com/gdanezis/lean-dag/issues/12) — *one liveness statement per arc, on the validator's view* — back into this repo's Hydrozoan mirror, exactly as applied on [gdanezis/lean-dag#8](https://github.com/gdanezis/lean-dag/pull/8) (commit `bb2c5ed`, "liveness on a view a replica can hold"), so the two mirrors do not diverge.

The liveness theorems concluded on the eventual view `View.full U` — sound (it is every correct replica's eventual view) but not a view any deployed replica holds. Now:

- `Model/Liveness.lean` adds `View.CoversUpto V N` — `V` holds every block of the universe at rounds ≤ `N` — next to `View.full`, whose docstring stops presenting itself as where liveness concludes.
- `CommitLiveness`, `RunDecidesBelow`, and `GroundedProgress` conclude on **any** view caught up to the relevant decision round; the single proof hinge is `slowCommitInView_of_coversUpto` at horizon `r + 2` (a caught-up view holds all certificates).
- The witnesses instantiate at `View.full` via `coversUpto_full`, re-deriving the exact old full-view forms.
- `check_no_holes.py` gains the equivalent of lean-dag's tripwire: `View.full` is forbidden in every `Statement.lean` and `Model/` file, with only the `def View.full` vocabulary site exempt.

Every file was verified byte-identical to lean-dag's pre-fix version (modulo the namespace re-homing) before porting, so the diff is exactly the upstream change. `lake build` green (814 jobs), `check_no_holes.py` green including the new tripwire.

Refs gdanezis/lean-dag#12 (item D there is the lean-dag side; this PR is the mysticeti-mirror counterpart — no issue to close here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XStsxDTWNepegmNy2VFhng