### PR TITLE
style(lean): use change, not show, for the CoversUpto defeq unfold

### DIFF
--- a/lean/HydrozoanTest/EventualDecision.lean
+++ b/lean/HydrozoanTest/EventualDecision.lean
@@ -107,7 +107,7 @@ def v10 : View U10 where
 
 /-- `v10` is caught up to the run's last decision round. -/
 theorem v10_coversUpto : v10.CoversUpto 6 := by
-  show ∀ b ∈ U10.ids, (U10.block b).round ≤ 6 → b ∈ v10.ids
+  change ∀ b ∈ U10.ids, (U10.block b).round ≤ 6 → b ∈ v10.ids
   decide
 
 -- Genuinely partial: the round-7 block 21 is outside.

--- a/lean/scripts/check_no_holes.py
+++ b/lean/scripts/check_no_holes.py
@@ -20,10 +20,11 @@ Additionally, every file named `Statement.lean` must be proof-free
 sit outside the audit convention that Statement files are read in full and
 proof files not at all.
 
-Finally, `View.full` may appear in no `Statement.lean` and no `Model/`
-file: a liveness statement concludes on a view a replica can hold
-(gdanezis/lean-dag#12). The `def View.full` site itself is vocabulary,
-not a claim, and is exempt.
+Finally, `View.full` may appear in the code of no `Statement.lean` and
+no `Model/` file: a liveness statement concludes on a view a replica
+can hold (gdanezis/lean-dag#12). Comments are stripped first, so prose
+may mention it; the `def View.full` site itself is vocabulary, not a
+claim, and is exempt.
 
 This script is part of the trusted base: it is meant to be read once,
 top to bottom, and then believed. Keep it dumb.
@@ -95,8 +96,8 @@ def main():
                         f"{match.group(1)} (proof material in a Statement file)"
                     )
             in_model = "Model" in path.relative_to(ROOT).parts
-            if (path.name == "Statement.lean" or in_model) \
-                    and FULLVIEW.search(code) and not FULLVIEW_DEF.search(code):
+            if ((path.name == "Statement.lean" or in_model)
+                    and FULLVIEW.search(code) and not FULLVIEW_DEF.search(code)):
                 holes.append(
                     f"{path.relative_to(ROOT)}:{lineno}: "
                     "View.full (a liveness statement concludes on a view)"


### PR DESCRIPTION
Follow-up to #236: `v10_coversUpto` used `show` to unfold `View.CoversUpto` to its decidable `∀` form, which trips `linter.style.show` ("this tactic invocation changed the goal — use `change` instead"). Swap it for `change`; same defeq check, warning-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XStsxDTWNepegmNy2VFhng