### PR TITLE
test(lean): kill the 3 ≤ c strengthening on RunDecidesBelow

### DIFF
--- a/lean/Hydrozoan/Helpers/SlotAgreement.lean
+++ b/lean/Hydrozoan/Helpers/SlotAgreement.lean
@@ -345,7 +345,7 @@ theorem not_certifiedIn_of_skipped {k : ℕ} {L : BlockId} {A : BlockId}
 
 end Skip
 
-/-! ## The anchor comparison (abstract, per lean-dag) -/
+/-! ## The anchor comparison (abstract) -/
 
 omit [Fintype Replica] [DecidableEq Replica] [DecidableEq BlockId] in
 /-- Two searches for the nearest eligible committed slot above `k`

--- a/lean/Hydrozoan/SlotAgreement/Proof.lean
+++ b/lean/Hydrozoan/SlotAgreement/Proof.lean
@@ -6,9 +6,9 @@ import Hydrozoan.DirectSafety.Proof
 # Slot agreement — proof
 
 Generated proof layer; not part of the audit surface. Structural
-induction on the first derivation (lean-dag's M6/O5 architecture): the
-motive quantifies over the second view and verdict, so the induction
-hypotheses cover any other replica's derivation. Direct-vs-direct
+induction on the first derivation: the motive quantifies over the
+second view and verdict, so the induction hypotheses cover any other
+replica's derivation. Direct-vs-direct
 pairings close by `DirectSafety`; direct-vs-indirect by the rung
 fires/starvation/skip lemmas of `Helpers/SlotAgreement.lean`;
 indirect-vs-indirect by the anchor comparison followed by the shared

--- a/lean/HydrozoanTest/DirectLiveness.lean
+++ b/lean/HydrozoanTest/DirectLiveness.lean
@@ -134,7 +134,9 @@ example : FastCommit U7 0 0 := by decide
 -- Statement hypothesis. (Disclosure: at this configuration
 -- f + c = 1 = p, so the fault hypothesis is satisfied by every
 -- admissible fault assignment — it does no work here; U6 above p is
--- where it bites.)
+-- where it bites. Also R = 0 = slotRound 0 sits at the R-boundary,
+-- so an `R = slotRound k` strengthening survives; a strict-R kill
+-- would need a sparse-schedule fast commit like U14's.)
 example : ∃ L, IsLeaderBlock U7 0 L ∧ FastCommit U7 L 0 :=
   DirectLiveness.fastLatency (Fin 4) (Fin 9) U7 0 0 (by decide)
     u7_synchronised (by decide) (by decide) (by decide) (by decide)

--- a/lean/HydrozoanTest/EventualDecision.lean
+++ b/lean/HydrozoanTest/EventualDecision.lean
@@ -84,10 +84,9 @@ theorem u10_populated : ∀ r, Slots.slotRound (Replica := Fin 4) 2 ≤ r →
 
 -- End-to-end: RunDecidesBelow applied to U10 at b = 2, c = 3 with every
 -- hypothesis discharged concretely — the mechanical guard against a
--- silently strengthened Statement hypothesis. (Known residual gap,
--- shared with the indirect-liveness descent witness: c = 3 also
--- satisfies a `3 ≤ c` strengthening; killing it needs a
--- faster-than-pipelined schedule.)
+-- silently strengthened Statement hypothesis. (A `3 ≤ c` strengthening
+-- also passes here; the c = 1 kill is U14's sparse-schedule run of
+-- length one, `LivenessHardening.lean`.)
 example : ∀ i, i < 2 → ∃ v, Decided U10 (View.full U10) i v :=
   (EventualDecision.holds (Fin 4) (Fin 24)).1 U10
     (Correct : Finset (Fin 4)) 0 2 3

--- a/lean/HydrozoanTest/LivenessHardening.lean
+++ b/lean/HydrozoanTest/LivenessHardening.lean
@@ -372,4 +372,23 @@ example : ∃ L, IsLeaderBlock U14 1 L ∧ SlowCommit U14 L 3 ∧
     (by decide) (by decide) (by decide)
     (View.full U14) (View.coversUpto_full U14 _)
 
+-- End-to-end: RunDecidesBelow below a run of length ONE — the
+-- run-witness half of the c = 1 kill (the descent half is above),
+-- closing the residual gap the pipelined U10 runs disclose.
+example : ∀ i, i < 1 → ∃ v, Decided U14 (View.full U14) i v :=
+  (EventualDecision.holds (Fin 6) (Fin 30)).1 U14
+    (Correct : Finset (Fin 6)) 0 1 1
+    (by decide) (by decide) u14_synchronised (by omega) spansEligible_six
+    (by decide)
+    (by intro i hi
+        have : i = 0 := by omega
+        subst this
+        decide)
+    (by intro r h1 h2
+        change 3 * (1 / 1) ≤ r at h1
+        change r ≤ 3 * ((1 + 1 - 1) / 1) + 2 at h2
+        have : r = 3 ∨ r = 4 ∨ r = 5 := by omega
+        rcases this with rfl | rfl | rfl <;> decide)
+    (View.full U14) (View.coversUpto_full U14 _)
+
 end HydrozoanTest

--- a/lean/scripts/check_no_holes.py
+++ b/lean/scripts/check_no_holes.py
@@ -22,9 +22,8 @@ proof files not at all.
 
 Finally, `View.full` may appear in the code of no `Statement.lean` and
 no `Model/` file: a liveness statement concludes on a view a replica
-can hold (gdanezis/lean-dag#12). Comments are stripped first, so prose
-may mention it; the `def View.full` site itself is vocabulary, not a
-claim, and is exempt.
+can hold. Comments are stripped first, so prose may mention it; the
+`def View.full` site itself is vocabulary, not a claim, and is exempt.
 
 This script is part of the trusted base: it is meant to be read once,
 top to bottom, and then believed. Keep it dumb.


### PR DESCRIPTION
Two follow-ups from the #236 work:

**Closes #250** — the vacuity-audit witness gaps:
- `RunDecidesBelow` is now applied below U14's length-one sparse-schedule run (`spansEligible_six` is already at `c = 1`), so strengthening its `0 < c` hypothesis to `3 ≤ c` fails the build. The `LivenessHardening` header's claim is now true for both the descent and run theorems.
- The stale U10 disclosure ("killing it needs a faster-than-pipelined schedule") repoints at the U14 kill.
- `FastLatency`'s `R = slotRound k`-only coverage is disclosed next to its U7 application (a strict-R kill would need a new sparse-schedule fast-commit table; not worth it for a performance characterization outside `Statement`).

**Independence sweep** — the formalization no longer references anything that resolves only in gdanezis/lean-dag: the "M6/O5 architecture" note in `SlotAgreement/Proof.lean`, the "per lean-dag" banner in `Helpers/SlotAgreement.lean`, and the external issue reference in `check_no_holes.py`'s tripwire rationale are rewritten self-contained. `lean/README.md` and `lean/CLAUDE.md` deliberately keep their mirror-relationship pointers.

`lake build` green (814 jobs), `check_no_holes.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XStsxDTWNepegmNy2VFhng