### PR TITLE
chore(ci): auto-merge dependabot and pre-commit update PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,20 @@
+name: Automerge
+on: pull_request
+permissions:
+  pull-requests: read
+jobs:
+  dependabot:
+    name: Enable auto-merge on dependabot PRs
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # pin@v3.1.0
+        id: metadata
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --rebase "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.AUTOMERGE_PAT }}

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -27,16 +27,22 @@ jobs:
       - run: pre-commit run --all-files
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # pin@v8.1.1
         if: ${{ success() }}
+        id: pr
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTOMERGE_PAT }}
           branch: chore/update-pre-commit-hooks
           title: "chore: update pre-commit hooks"
           commit-message: "chore: update pre-commit hooks"
           body: Update pre-commit hooks to latest version.
+      - name: Enable auto-merge
+        if: ${{ success() && steps.pr.outputs.pull-request-number }}
+        run: gh pr merge --auto --rebase "${{ steps.pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMERGE_PAT }}
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # pin@v8.1.1
         if: ${{ failure() }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTOMERGE_PAT }}
           branch: chore/update-pre-commit-hooks
           title: "chore: update pre-commit hooks"
           commit-message: "chore: update pre-commit hooks"


### PR DESCRIPTION
Green dependabot and pre-commit-update PRs currently sit unmerged until someone lands them by hand (see #232–#235). Two changes make them self-landing:

- **New `automerge.yml`**: on every dependabot PR, arm GitHub auto-merge (rebase) unless the bump is semver-major — majors stay held for review. Uses `dependabot/fetch-metadata` to classify the update.
- **`updates.yml`**: the monthly pre-commit PR is now created with the `AUTOMERGE_PAT` fine-grained token instead of `GITHUB_TOKEN`, so its CI runs without manual workflow approval; the success-path PR also arms auto-merge.

Auto-merge is armed with the PAT (not `GITHUB_TOKEN`) so the eventual merge to `main` still triggers the push-time workflows.

Requires the `AUTOMERGE_PAT` repo secret (already configured): fine-grained, this repo only, Contents + Pull requests read/write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NmNqeLPdDn4bjrjEdvZGz