### PR TITLE
chore: bump Rust toolchain to 1.98

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ experimentation — **not production** — but uses real networking, cryptograph
 persistent storage. Ships with a discrete-event simulator and a cloud orchestrator for
 running the protocols under custom scenarios.
 
-Rust **edition 2024**, toolchain pinned to **1.92** (see `rust-toolchain.toml`).
+Rust **edition 2024**, toolchain pinned to **1.98** (see `rust-toolchain.toml`).
 
 ## Workspace layout
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![build
 status](https://img.shields.io/github/actions/workflow/status/asonnino/mysticeti/code.yaml?branch=main&logo=github&style=flat-square)](https://github.com/asonnino/mysticeti/actions)
-[![rustc](https://img.shields.io/badge/rustc-1.92+-blue?style=flat-square&logo=rust)](https://www.rust-lang.org)
+[![rustc](https://img.shields.io/badge/rustc-1.98+-blue?style=flat-square&logo=rust)](https://www.rust-lang.org)
 [![license](https://img.shields.io/badge/license-Apache-blue.svg?style=flat-square)](LICENSE)
 
 This repository provides reference implementations of several uncertified DAG-based consensus

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.97"
+channel = "1.98"
 components = ["clippy", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
Bump the pinned toolchain from 1.97 to 1.98.0 (stable since 2026-08-18), and refresh the README rustc badge and CLAUDE.md toolchain note, both of which still said 1.92.

On 1.98: `cargo fmt --check` clean, workspace clippy clean (no new lints), full test suite green (40/40 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NmNqeLPdDn4bjrjEdvZGz