### PR TITLE
feat(consensus): asynchronous Blue Bottle variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ network and failure scenarios.
 
 This repository currently supports [Mysticeti](https://sonnino.com/papers/mysticeti.pdf),
 [Mahi-Mahi](https://sonnino.com/papers/mahi-mahi.pdf),
-[Blue Bottle](https://sonnino.com/papers/bluebottle.pdf), [Cordial
-Miners](https://arxiv.org/abs/2205.09174) (both the partially synchronous and asynchronous
+[Blue Bottle](https://sonnino.com/papers/bluebottle.pdf) (both the partially synchronous and asynchronous
+variants),
+[Cordial Miners](https://arxiv.org/abs/2205.09174) (both the partially synchronous and asynchronous
 variants), [Nemo-Nemo](https://sonnino.com/papers/nemo-nemo.pdf),
 [Orcaella](https://sonnino.com/papers/orcaella.pdf), and a DAG variant of
 [Hydrangea](https://eprint.iacr.org/2025/1112).

--- a/crates/consensus/src/base.rs
+++ b/crates/consensus/src/base.rs
@@ -456,6 +456,7 @@ mod tests {
         block::Block,
         consensus::LeaderStatus,
         crypto::BlockDigest,
+        data::Data,
         storage::Storage,
         test_util::{build_dag, build_dag_layer, committee, insert_test_block},
     };
@@ -919,6 +920,187 @@ mod tests {
                 assert_eq!(block.reference().digest, twin_a_digest);
             }
             other => panic!("expected IndirectCommit, got {other:?}"),
+        }
+    }
+
+    /// Async Blue Bottle committer over a 6-validator committee (strong quorum 5,
+    /// weak quorum 3), with round-robin leaders standing in for the coin.
+    fn blue_bottle_async_committer(
+        committee: &std::sync::Arc<dag::committee::Committee>,
+        storage: &Storage,
+    ) -> BaseCommitter {
+        let protocol = Protocol::blue_bottle_asynchronous(
+            committee.total_stake(),
+            NonZeroUsize::new(1).unwrap(),
+        );
+        BaseCommitter::new(
+            committee.clone(),
+            storage.block_reader().clone(),
+            LeaderElector::new(committee.len()),
+            &protocol,
+            0,
+            0,
+        )
+    }
+
+    /// Async Blue Bottle: a fully-connected DAG holds a strong certificate (5 of 6
+    /// decision-round votes) at round `r + 2`, so the leader direct-commits.
+    #[test]
+    fn blue_bottle_async_direct_commits_on_full_dag() {
+        let committee = committee(6);
+        let mut storage = Storage::new_for_test(&committee);
+        build_dag(&committee, &mut storage, None, 5);
+        let committer = blue_bottle_async_committer(&committee, &storage);
+
+        let leader = committer.elect_leader(3).unwrap();
+        match committer.try_direct_decide(leader, 3) {
+            LeaderStatus::DirectCommit(block) => assert_eq!(block.author(), leader),
+            other => panic!("expected DirectCommit, got {other:?}"),
+        }
+    }
+
+    /// Async Blue Bottle: 5 of 6 decision-round blocks without a path to the leader
+    /// form the slot-blame witness, so the leader direct-skips.
+    #[test]
+    fn blue_bottle_async_direct_skips_when_leader_omitted() {
+        let committee = committee(6);
+        let mut storage = Storage::new_for_test(&committee);
+
+        let references_at_leader = build_dag(&committee, &mut storage, None, 3);
+        // Round-robin: round 3 → authority 3.
+        let leader = committee.authorities().nth(3).unwrap();
+        let references_without_leader: Vec<_> = references_at_leader
+            .into_iter()
+            .filter(|reference| reference.authority != leader)
+            .collect();
+        let boost_connections = committee
+            .authorities()
+            .map(|authority| (authority, references_without_leader.clone()))
+            .collect();
+        let references_at_boost_round = build_dag_layer(boost_connections, &mut storage);
+        build_dag(&committee, &mut storage, Some(references_at_boost_round), 5);
+
+        let committer = blue_bottle_async_committer(&committee, &storage);
+        match committer.try_direct_decide(leader, 3) {
+            LeaderStatus::DirectSkip(skipped, round) => {
+                assert_eq!(skipped, leader);
+                assert_eq!(round, 3);
+            }
+            other => panic!("expected DirectSkip, got {other:?}"),
+        }
+    }
+
+    /// Async Blue Bottle DAG where only the first `supporter_count` authorities keep
+    /// a path to the round-3 leader through the decision round, under a fully-linked
+    /// anchor at round 6.
+    fn blue_bottle_async_partial_support(
+        committee: &std::sync::Arc<dag::committee::Committee>,
+        supporter_count: usize,
+    ) -> (Storage, Data<Block>, Authority) {
+        let mut storage = Storage::new_for_test(committee);
+
+        let leader_round = 3;
+        let references_at_leader = build_dag(committee, &mut storage, None, leader_round);
+        // Round-robin: round 3 → authority 3.
+        let leader = committee.authorities().nth(3).unwrap();
+        let references_without_leader: Vec<_> = references_at_leader
+            .iter()
+            .copied()
+            .filter(|reference| reference.authority != leader)
+            .collect();
+
+        // Boost round: only the supporters keep a path to the leader.
+        let supporters: Vec<_> = committee.authorities().take(supporter_count).collect();
+        let boost_connections = committee
+            .authorities()
+            .map(|authority| {
+                let parents = if supporters.contains(&authority) {
+                    references_at_leader.clone()
+                } else {
+                    references_without_leader.clone()
+                };
+                (authority, parents)
+            })
+            .collect();
+        let references_at_boost_round = build_dag_layer(boost_connections, &mut storage);
+        let (supporting_boost, blaming_boost): (Vec<_>, Vec<_>) = references_at_boost_round
+            .into_iter()
+            .partition(|reference| supporters.contains(&reference.authority));
+
+        // Decision round: exactly `supporter_count` votes, the rest blames.
+        let decision_connections = committee
+            .authorities()
+            .map(|authority| {
+                let parents = if supporters.contains(&authority) {
+                    supporting_boost.clone()
+                } else {
+                    blaming_boost.clone()
+                };
+                (authority, parents)
+            })
+            .collect();
+        let references_at_decision_round = build_dag_layer(decision_connections, &mut storage);
+
+        // Anchor round: fully connected, so the anchor links every decision block.
+        build_dag(
+            committee,
+            &mut storage,
+            Some(references_at_decision_round),
+            6,
+        );
+        let anchor = storage
+            .block_reader()
+            .get_blocks_at_authority_round(committee.authorities().next().unwrap(), 6)
+            .into_iter()
+            .next()
+            .unwrap();
+
+        (storage, anchor, leader)
+    }
+
+    /// Async Blue Bottle: 3 decision-round votes miss the strong quorum (5) but form
+    /// a weak certificate (3) in the anchor's history, so the leader stays undecided
+    /// directly and indirect-commits.
+    #[test]
+    fn blue_bottle_async_weak_certificate_indirect_commits() {
+        let committee = committee(6);
+        let (storage, anchor, leader) = blue_bottle_async_partial_support(&committee, 3);
+
+        let committer = blue_bottle_async_committer(&committee, &storage);
+        match committer.try_direct_decide(leader, 3) {
+            LeaderStatus::Undecided(authority, round) => {
+                assert_eq!(authority, leader);
+                assert_eq!(round, 3);
+            }
+            other => panic!("expected Undecided, got {other:?}"),
+        }
+        match committer.decide_leader_from_anchor(&anchor, leader, 3) {
+            LeaderStatus::IndirectCommit(block) => assert_eq!(block.author(), leader),
+            other => panic!("expected IndirectCommit, got {other:?}"),
+        }
+    }
+
+    /// Async Blue Bottle: 2 decision-round votes stay below the weak certificate
+    /// quorum (3), so the anchor indirect-skips the leader.
+    #[test]
+    fn blue_bottle_async_below_weak_certificate_indirect_skips() {
+        let committee = committee(6);
+        let (storage, anchor, leader) = blue_bottle_async_partial_support(&committee, 2);
+
+        let committer = blue_bottle_async_committer(&committee, &storage);
+        match committer.try_direct_decide(leader, 3) {
+            LeaderStatus::Undecided(authority, round) => {
+                assert_eq!(authority, leader);
+                assert_eq!(round, 3);
+            }
+            other => panic!("expected Undecided, got {other:?}"),
+        }
+        match committer.decide_leader_from_anchor(&anchor, leader, 3) {
+            LeaderStatus::IndirectSkip(authority, round) => {
+                assert_eq!(authority, leader);
+                assert_eq!(round, 3);
+            }
+            other => panic!("expected IndirectSkip, got {other:?}"),
         }
     }
 

--- a/crates/consensus/src/base.rs
+++ b/crates/consensus/src/base.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
+    borrow::Borrow,
     fmt::{self, Display},
     sync::Arc,
 };
@@ -58,7 +59,11 @@ impl BaseCommitter {
             certificate_quorum: protocol.certificate_quorum,
             fast_path: protocol.fast_path,
             anchor_link_size: protocol.anchor_link_size,
-            wave: Wave::new(protocol.wave_length, round_offset),
+            wave: Wave::new(
+                protocol.wave_length,
+                round_offset,
+                protocol.merged_certificates,
+            ),
             leader_offset,
         }
     }
@@ -80,6 +85,7 @@ impl BaseCommitter {
             fast_path: None,
             anchor_link_size: 1,
             wave_length,
+            merged_certificates: wave_length == 2,
             leader_count: std::num::NonZeroUsize::new(1).unwrap(),
             pipeline: false,
             leader_wait: false,
@@ -150,37 +156,46 @@ impl BaseCommitter {
         self.find_support((author, round), potential_vote) == Some(*leader_block.reference())
     }
 
-    /// Check whether the specified block (`potential_certificate`) is a certificate for
-    /// the specified leader (`leader_block`).
-    fn is_certificate(
-        &self,
-        potential_certificate: &Data<Block>,
-        leader_block: &Data<Block>,
-    ) -> bool {
-        // When the certificate sits exactly one round above the leader (i.e.
-        // `wave_length == 2`), votes and certificates coincide on the same round:
-        // each decision-round block that directly supports the leader is itself a
-        // certificate.
-        if potential_certificate.round() == leader_block.round() + 1 {
-            return self.is_vote(potential_certificate, leader_block);
-        }
-
-        let mut votes_stake_aggregator = StakeAggregator::new(self.certificate_quorum);
-        for reference in potential_certificate.includes() {
-            let potential_vote = self
-                .block_reader
-                .get_block(*reference)
-                .expect("We should have the whole sub-dag by now");
-
-            if self.is_vote(&potential_vote, leader_block) {
-                tracing::trace!("[{self}] {potential_vote:?} is a vote for {leader_block:?}");
-                if votes_stake_aggregator.add(reference.authority, &self.committee) {
-                    tracing::trace!(
-                        "[{self}] {potential_certificate:?} is a certificate for {leader_block:?}"
-                    );
+    /// Check whether `votes` holds a `quorum` of distinct-author votes for
+    /// `leader_block`, i.e. whether they form a certificate for it.
+    fn is_certificate<I, B>(&self, votes: I, leader_block: &Data<Block>, quorum: Stake) -> bool
+    where
+        I: IntoIterator<Item = B>,
+        B: Borrow<Data<Block>>,
+    {
+        let mut votes_stake_aggregator = StakeAggregator::new(quorum);
+        for vote in votes {
+            let vote = vote.borrow();
+            if self.is_vote(vote, leader_block) {
+                // Merged protocols never traced per vote; keep their hot path unchanged.
+                if !self.wave.merged_certificates() {
+                    tracing::trace!("[{self}] {vote:?} is a vote for {leader_block:?}");
+                }
+                if votes_stake_aggregator.add(vote.author(), &self.committee) {
                     return true;
                 }
             }
+        }
+        false
+    }
+
+    /// Check whether the specified decision-round block references a certificate for
+    /// `leader_block` (the vote-and-certify pattern).
+    fn carries_certificate(
+        &self,
+        decision_block: &Data<Block>,
+        leader_block: &Data<Block>,
+    ) -> bool {
+        let votes = decision_block.includes().iter().map(|reference| {
+            self.block_reader
+                .get_block(*reference)
+                .expect("We should have the whole sub-dag by now")
+        });
+        if self.is_certificate(votes, leader_block, self.certificate_quorum) {
+            tracing::trace!(
+                "[{self}] {decision_block:?} carries a certificate for {leader_block:?}"
+            );
+            return true;
         }
         false
     }
@@ -207,20 +222,23 @@ impl BaseCommitter {
         let decision_round = self.wave.decision_round(wave);
         let decision_blocks = self.block_reader.get_blocks_by_round(decision_round);
 
-        // Find the leader block with a certified link to the anchor. With a
-        // strong-quorum certificate this is unique; at `wave_length == 2` the
-        // certificate degenerates to a weak vote and two equivocating twins can both
-        // qualify, so break ties deterministically by digest.
+        // Find the leader block whose certificate is linked to the anchor: with
+        // merged certificates, an `anchor_link_size` quorum of anchor-linked votes;
+        // otherwise, `anchor_link_size` anchor-linked certificate-carrying blocks.
+        // A weak (sub-majority) quorum lets two equivocating twins both qualify,
+        // so break ties deterministically by digest.
         let certified = leader_blocks.iter().filter(|leader_block| {
+            if self.wave.merged_certificates() {
+                let linked_votes = decision_blocks
+                    .iter()
+                    .filter(|block| self.block_reader.linked(anchor, block));
+                return self.is_certificate(linked_votes, leader_block, self.anchor_link_size);
+            }
             let mut aggregator = StakeAggregator::new(self.anchor_link_size);
             decision_blocks.iter().any(|block| {
-                if !self.block_reader.linked(anchor, block) {
-                    return false;
-                }
-                if !self.is_certificate(block, leader_block) {
-                    return false;
-                }
-                aggregator.add(block.author(), &self.committee)
+                self.block_reader.linked(anchor, block)
+                    && self.carries_certificate(block, leader_block)
+                    && aggregator.add(block.author(), &self.committee)
             })
         });
         let commit = certified.min_by_key(|leader_block| leader_block.reference().digest);
@@ -283,8 +301,10 @@ impl BaseCommitter {
         false
     }
 
-    /// Check whether the specified leader has enough support (`direct_commit_quorum`
-    /// certificates) to be directly committed.
+    /// Check whether the specified leader has enough support to be directly
+    /// committed: with merged certificates, a `direct_commit_quorum` certificate of
+    /// decision-round votes; otherwise, `direct_commit_quorum` certificate-carrying
+    /// blocks at the decision round.
     fn enough_leader_support(
         &self,
         decision_round: RoundNumber,
@@ -292,10 +312,15 @@ impl BaseCommitter {
     ) -> bool {
         let decision_blocks = self.block_reader.get_blocks_by_round(decision_round);
 
+        if self.wave.merged_certificates() {
+            let votes = decision_blocks.iter();
+            return self.is_certificate(votes, leader_block, self.direct_commit_quorum);
+        }
+
         let mut certificate_stake_aggregator = StakeAggregator::new(self.direct_commit_quorum);
         for decision_block in &decision_blocks {
             let authority = decision_block.reference().authority;
-            if self.is_certificate(decision_block, leader_block)
+            if self.carries_certificate(decision_block, leader_block)
                 && certificate_stake_aggregator.add(authority, &self.committee)
             {
                 return true;
@@ -543,10 +568,9 @@ mod tests {
         );
     }
 
-    /// At `wave_length = 2`, votes and certificates coincide on the same round:
-    /// `is_certificate` reduces to `is_vote`.
+    /// `is_certificate` aggregates distinct-author votes against the given quorum.
     #[test]
-    fn is_certificate_wave_length_two_reduces_to_vote() {
+    fn is_certificate_counts_distinct_vote_quorum() {
         let committee = committee(4);
         let mut storage = Storage::new_for_test(&committee);
         build_dag(&committee, &mut storage, None, 3);
@@ -559,20 +583,18 @@ mod tests {
             .into_iter()
             .next()
             .unwrap();
-        let certificate_candidate = storage
-            .block_reader()
-            .get_blocks_at_authority_round(Authority::from(1u64), 3)
-            .into_iter()
-            .next()
-            .unwrap();
+        let votes = storage.block_reader().get_blocks_by_round(3);
 
-        assert!(committer.is_certificate(&certificate_candidate, &leader_block));
+        // A fully-connected round of 4 votes reaches quorum 4 but not 5.
+        assert!(committer.is_certificate(votes.iter(), &leader_block, 4));
+        assert!(!committer.is_certificate(votes.iter(), &leader_block, 5));
     }
 
     /// At `wave_length = 3`, a fully-connected DAG produces a strong-quorum of votes
-    /// under each decision-round block, so every decision-round block is a certificate.
+    /// under each decision-round block, so every decision-round block carries a
+    /// certificate.
     #[test]
-    fn is_certificate_wave_length_three_full_dag() {
+    fn carries_certificate_wave_length_three_full_dag() {
         let committee = committee(4);
         let mut storage = Storage::new_for_test(&committee);
         build_dag(&committee, &mut storage, None, 5);
@@ -592,7 +614,7 @@ mod tests {
             .next()
             .unwrap();
 
-        assert!(committer.is_certificate(&certificate_candidate, &leader_block));
+        assert!(committer.carries_certificate(&certificate_candidate, &leader_block));
     }
 
     /// `enough_leader_blame` is `true` when every non-leader voter omits the leader.
@@ -878,8 +900,10 @@ mod tests {
             .next()
             .unwrap();
 
-        let protocol =
-            Protocol::blue_bottle(committee.total_stake(), NonZeroUsize::new(1).unwrap());
+        let protocol = Protocol::blue_bottle_partially_synchronous(
+            committee.total_stake(),
+            NonZeroUsize::new(1).unwrap(),
+        );
         let committer = BaseCommitter::new(
             committee.clone(),
             storage.block_reader().clone(),

--- a/crates/consensus/src/committer.rs
+++ b/crates/consensus/src/committer.rs
@@ -248,6 +248,7 @@ mod tests {
             fast_path,
             anchor_link_size: 1,
             wave_length: 3,
+            merged_certificates: false,
             leader_count: NonZeroUsize::new(1).unwrap(),
             pipeline: false,
             leader_wait: true,

--- a/crates/consensus/src/protocol.rs
+++ b/crates/consensus/src/protocol.rs
@@ -27,6 +27,10 @@ pub enum ConsensusProtocol {
         #[serde(default = "defaults::default_leader_count")]
         leader_count: NonZeroUsize,
     },
+    BlueBottleAsynchronous {
+        #[serde(default = "defaults::default_leader_count")]
+        leader_count: NonZeroUsize,
+    },
     Orcaella {
         #[serde(default = "defaults::default_leader_count")]
         leader_count: NonZeroUsize,
@@ -102,6 +106,9 @@ impl fmt::Display for ConsensusProtocol {
             Self::BlueBottlePartiallySynchronous { leader_count } => {
                 write!(fmt, "Blue Bottle PS ({} leaders/round)", leader_count)
             }
+            Self::BlueBottleAsynchronous { leader_count } => {
+                write!(fmt, "Blue Bottle Async ({} leaders/round)", leader_count)
+            }
             Self::Orcaella { leader_count, f, c } => {
                 write!(
                     fmt,
@@ -147,6 +154,9 @@ impl fmt::Debug for ConsensusProtocol {
             Self::BlueBottlePartiallySynchronous { leader_count } => {
                 write!(fmt, "blue-bottle-ps-l{leader_count}")
             }
+            Self::BlueBottleAsynchronous { leader_count } => {
+                write!(fmt, "blue-bottle-async-l{leader_count}")
+            }
             Self::Orcaella { leader_count, f, c } => {
                 write!(fmt, "orcaella-l{leader_count}-f{f}-c{c}")
             }
@@ -174,6 +184,7 @@ impl ConsensusProtocol {
             Self::CordialMinersPartiallySynchronous | Self::CordialMinersAsynchronous => None,
             Self::Mysticeti { leader_count }
             | Self::BlueBottlePartiallySynchronous { leader_count }
+            | Self::BlueBottleAsynchronous { leader_count }
             | Self::Orcaella { leader_count, .. }
             | Self::MahiMahi { leader_count, .. }
             | Self::NemoNemo { leader_count }
@@ -196,6 +207,9 @@ impl ConsensusProtocol {
             Self::Mysticeti { leader_count } => Protocol::mysticeti(total_stake, leader_count),
             Self::BlueBottlePartiallySynchronous { leader_count } => {
                 Protocol::blue_bottle_partially_synchronous(total_stake, leader_count)
+            }
+            Self::BlueBottleAsynchronous { leader_count } => {
+                Protocol::blue_bottle_asynchronous(total_stake, leader_count)
             }
             Self::Orcaella { leader_count, f, c } => {
                 Protocol::orcaella(total_stake, f, c, leader_count)?
@@ -226,6 +240,7 @@ impl ConsensusProtocol {
             let leader_count = NonZeroUsize::new(l).expect("leader_count must be non-zero");
             variants.push(Self::Mysticeti { leader_count });
             variants.push(Self::BlueBottlePartiallySynchronous { leader_count });
+            variants.push(Self::BlueBottleAsynchronous { leader_count });
             variants.push(Self::NemoNemo { leader_count });
             variants.push(Self::Orcaella {
                 leader_count,
@@ -497,6 +512,29 @@ impl Protocol {
             leader_count,
             pipeline: true,
             leader_wait: true,
+            require_crypto: true,
+        }
+    }
+
+    /// Blue Bottle (asynchronous variant)
+    ///
+    /// "BlueBottle: Fast and Robust Blockchains through Subsystem Specialization"
+    /// <https://sonnino.com/papers/bluebottle.pdf>
+    pub fn blue_bottle_asynchronous(total_stake: Stake, leader_count: NonZeroUsize) -> Self {
+        let strong_quorum = 4 * total_stake / 5 + 1;
+        let weak_quorum = 2 * total_stake / 5 + 1;
+        Self {
+            direct_commit_quorum: strong_quorum,
+            direct_skip_quorum: strong_quorum,
+            certificate_quorum: strong_quorum,
+            quorum_threshold: strong_quorum,
+            fast_path: None,
+            anchor_link_size: weak_quorum,
+            wave_length: 3,
+            merged_certificates: true,
+            leader_count,
+            pipeline: true,
+            leader_wait: false,
             require_crypto: true,
         }
     }

--- a/crates/consensus/src/protocol.rs
+++ b/crates/consensus/src/protocol.rs
@@ -23,7 +23,7 @@ pub enum ConsensusProtocol {
         #[serde(default = "defaults::default_leader_count")]
         leader_count: NonZeroUsize,
     },
-    BlueBottle {
+    BlueBottlePartiallySynchronous {
         #[serde(default = "defaults::default_leader_count")]
         leader_count: NonZeroUsize,
     },
@@ -99,8 +99,8 @@ impl fmt::Display for ConsensusProtocol {
             Self::Mysticeti { leader_count } => {
                 write!(fmt, "Mysticeti ({} leaders/round)", leader_count)
             }
-            Self::BlueBottle { leader_count } => {
-                write!(fmt, "Blue Bottle ({} leaders/round)", leader_count)
+            Self::BlueBottlePartiallySynchronous { leader_count } => {
+                write!(fmt, "Blue Bottle PS ({} leaders/round)", leader_count)
             }
             Self::Orcaella { leader_count, f, c } => {
                 write!(
@@ -144,7 +144,9 @@ impl fmt::Debug for ConsensusProtocol {
             Self::CordialMinersPartiallySynchronous => write!(fmt, "cordial-miners-ps"),
             Self::CordialMinersAsynchronous => write!(fmt, "cordial-miners-async"),
             Self::Mysticeti { leader_count } => write!(fmt, "mysticeti-l{leader_count}"),
-            Self::BlueBottle { leader_count } => write!(fmt, "blue-bottle-l{leader_count}"),
+            Self::BlueBottlePartiallySynchronous { leader_count } => {
+                write!(fmt, "blue-bottle-ps-l{leader_count}")
+            }
             Self::Orcaella { leader_count, f, c } => {
                 write!(fmt, "orcaella-l{leader_count}-f{f}-c{c}")
             }
@@ -171,7 +173,7 @@ impl ConsensusProtocol {
         let user_leader_count = match self {
             Self::CordialMinersPartiallySynchronous | Self::CordialMinersAsynchronous => None,
             Self::Mysticeti { leader_count }
-            | Self::BlueBottle { leader_count }
+            | Self::BlueBottlePartiallySynchronous { leader_count }
             | Self::Orcaella { leader_count, .. }
             | Self::MahiMahi { leader_count, .. }
             | Self::NemoNemo { leader_count }
@@ -192,7 +194,9 @@ impl ConsensusProtocol {
             }
             Self::CordialMinersAsynchronous => Protocol::cordial_miners_asynchronous(total_stake),
             Self::Mysticeti { leader_count } => Protocol::mysticeti(total_stake, leader_count),
-            Self::BlueBottle { leader_count } => Protocol::blue_bottle(total_stake, leader_count),
+            Self::BlueBottlePartiallySynchronous { leader_count } => {
+                Protocol::blue_bottle_partially_synchronous(total_stake, leader_count)
+            }
             Self::Orcaella { leader_count, f, c } => {
                 Protocol::orcaella(total_stake, f, c, leader_count)?
             }
@@ -221,7 +225,7 @@ impl ConsensusProtocol {
         for &l in leader_counts {
             let leader_count = NonZeroUsize::new(l).expect("leader_count must be non-zero");
             variants.push(Self::Mysticeti { leader_count });
-            variants.push(Self::BlueBottle { leader_count });
+            variants.push(Self::BlueBottlePartiallySynchronous { leader_count });
             variants.push(Self::NemoNemo { leader_count });
             variants.push(Self::Orcaella {
                 leader_count,
@@ -391,6 +395,9 @@ pub struct Protocol {
     pub anchor_link_size: Stake,
     /// The number of rounds to commit a leader.
     pub wave_length: RoundNumber,
+    /// Whether decision-round votes are themselves the certificates (no certify
+    /// round); forced by geometry at `wave_length == 2`.
+    pub merged_certificates: bool,
     /// The number of leaders per round.
     pub leader_count: NonZeroUsize,
     /// Whether the protocol commits one leader per round.
@@ -416,6 +423,7 @@ impl Protocol {
             fast_path: None,
             anchor_link_size: 1,
             wave_length: 3,
+            merged_certificates: false,
             leader_count: NonZeroUsize::new(1).unwrap(),
             pipeline: false,
             leader_wait: true,
@@ -437,6 +445,7 @@ impl Protocol {
             fast_path: None,
             anchor_link_size: 1,
             wave_length: 5,
+            merged_certificates: false,
             leader_count: NonZeroUsize::new(1).unwrap(),
             pipeline: false,
             leader_wait: false,
@@ -458,6 +467,7 @@ impl Protocol {
             fast_path: None,
             anchor_link_size: 1,
             wave_length: 3,
+            merged_certificates: false,
             leader_count,
             pipeline: true,
             leader_wait: true,
@@ -465,11 +475,14 @@ impl Protocol {
         }
     }
 
-    /// Blue Bottle
+    /// Blue Bottle (partially synchronous variant)
     ///
     /// "BlueBottle: Fast and Robust Blockchains through Subsystem Specialization"
     /// <https://sonnino.com/papers/bluebottle.pdf>
-    pub fn blue_bottle(total_stake: Stake, leader_count: NonZeroUsize) -> Self {
+    pub fn blue_bottle_partially_synchronous(
+        total_stake: Stake,
+        leader_count: NonZeroUsize,
+    ) -> Self {
         let strong_quorum = 4 * total_stake / 5 + 1;
         let weak_quorum = 2 * total_stake / 5 + 1;
         Self {
@@ -480,6 +493,7 @@ impl Protocol {
             fast_path: None,
             anchor_link_size: weak_quorum,
             wave_length: 2,
+            merged_certificates: true,
             leader_count,
             pipeline: true,
             leader_wait: true,
@@ -514,6 +528,7 @@ impl Protocol {
             fast_path: None,
             anchor_link_size: total_stake - 3 * f - 2 * c,
             wave_length: 2,
+            merged_certificates: true,
             leader_count,
             pipeline: true,
             leader_wait: true,
@@ -543,6 +558,7 @@ impl Protocol {
             fast_path: None,
             anchor_link_size: 1,
             wave_length,
+            merged_certificates: false,
             leader_count,
             pipeline: true,
             leader_wait: false,
@@ -564,6 +580,7 @@ impl Protocol {
             fast_path: None,
             anchor_link_size: 1,
             wave_length: 2,
+            merged_certificates: true,
             leader_count,
             pipeline: true,
             leader_wait: true,
@@ -620,6 +637,7 @@ impl Protocol {
             fast_path: Some(fast_path),
             anchor_link_size: 1,
             wave_length: 3,
+            merged_certificates: false,
             leader_count,
             pipeline: true,
             leader_wait: true,

--- a/crates/consensus/src/wave.rs
+++ b/crates/consensus/src/wave.rs
@@ -12,18 +12,28 @@ pub(crate) type WaveNumber = RoundNumber;
 pub(crate) struct Wave {
     wave_length: RoundNumber,
     round_offset: RoundNumber,
+    merged_certificates: bool,
 }
 
 impl Wave {
-    pub(crate) fn new(wave_length: RoundNumber, round_offset: RoundNumber) -> Self {
+    pub(crate) fn new(
+        wave_length: RoundNumber,
+        round_offset: RoundNumber,
+        merged_certificates: bool,
+    ) -> Self {
         debug_assert!(wave_length > 0, "wave_length must be positive");
         debug_assert!(
             round_offset < wave_length,
             "round_offset must be < wave_length",
         );
+        debug_assert!(
+            wave_length > 2 || merged_certificates,
+            "a wave without a certify round must merge certificates",
+        );
         Self {
             wave_length,
             round_offset,
+            merged_certificates,
         }
     }
 
@@ -35,6 +45,12 @@ impl Wave {
     #[inline]
     pub(crate) fn round_offset(&self) -> RoundNumber {
         self.round_offset
+    }
+
+    /// Whether decision-round votes are themselves the certificates (no certify round).
+    #[inline]
+    pub(crate) fn merged_certificates(&self) -> bool {
+        self.merged_certificates
     }
 
     /// Return the wave in which the specified round belongs.
@@ -55,12 +71,15 @@ impl Wave {
         self.leader_round(wave) + self.wave_length - 1
     }
 
-    /// Return the voting round of the specified wave.
+    /// Return the voting round of the specified wave; with merged certificates it
+    /// coincides with the decision round.
     #[inline]
     pub(crate) fn voting_round(&self, wave: WaveNumber) -> RoundNumber {
-        let leader_round = self.leader_round(wave);
         let decision_round = self.decision_round(wave);
-        (leader_round + 1).max(decision_round - 1)
+        if self.merged_certificates {
+            return decision_round;
+        }
+        (self.leader_round(wave) + 1).max(decision_round - 1)
     }
 
     /// True iff `round` is the leader round of some wave.
@@ -82,7 +101,7 @@ mod tests {
     #[test]
     fn leader_round_inverse_of_number() {
         for (wave_length, round_offset) in configs() {
-            let wave = Wave::new(wave_length, round_offset);
+            let wave = Wave::new(wave_length, round_offset, wave_length == 2);
             for wave_number in 0..4 {
                 let leader_round = wave.leader_round(wave_number);
                 assert_eq!(
@@ -97,7 +116,7 @@ mod tests {
     #[test]
     fn decision_round_relation() {
         for (wave_length, round_offset) in configs() {
-            let wave = Wave::new(wave_length, round_offset);
+            let wave = Wave::new(wave_length, round_offset, wave_length == 2);
             for wave_number in 0..4 {
                 assert_eq!(
                     wave.decision_round(wave_number),
@@ -110,7 +129,7 @@ mod tests {
     #[test]
     fn voting_round_collapses_when_wl_is_two() {
         for round_offset in 0..2 {
-            let wave = Wave::new(2, round_offset);
+            let wave = Wave::new(2, round_offset, true);
             for wave_number in 0..3 {
                 let leader_round = wave.leader_round(wave_number);
                 let decision_round = wave.decision_round(wave_number);
@@ -124,7 +143,7 @@ mod tests {
     #[test]
     fn is_leader_round_matches_modulo() {
         for (wave_length, round_offset) in configs() {
-            let wave = Wave::new(wave_length, round_offset);
+            let wave = Wave::new(wave_length, round_offset, wave_length == 2);
             for round in 0..20 {
                 let expected = round >= round_offset && (round - round_offset) % wave_length == 0;
                 assert_eq!(
@@ -188,7 +207,7 @@ mod tests {
             expected_voting,
         ) in TABLE
         {
-            let wave = Wave::new(wave_length, round_offset);
+            let wave = Wave::new(wave_length, round_offset, wave_length == 2);
             let wave_number = wave.number(round);
             assert_eq!(
                 wave_number, expected_wave,
@@ -212,17 +231,40 @@ mod tests {
         }
     }
 
+    /// With merged certificates the voting round coincides with the decision round
+    /// at any wave length.
+    #[test]
+    fn voting_round_merged_certificates() {
+        for (wave_length, round_offset) in configs() {
+            let wave = Wave::new(wave_length, round_offset, true);
+            for wave_number in 0..3 {
+                assert_eq!(
+                    wave.voting_round(wave_number),
+                    wave.decision_round(wave_number),
+                    "voting_round mismatch for ({wave_length}, {round_offset}, {wave_number})",
+                );
+            }
+        }
+    }
+
     #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "wave_length must be positive")]
     fn new_panics_on_zero_wave_length() {
-        Wave::new(0, 0);
+        Wave::new(0, 0, true);
     }
 
     #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "round_offset must be < wave_length")]
     fn new_panics_on_offset_ge_wave_length() {
-        Wave::new(3, 3);
+        Wave::new(3, 3, false);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "must merge certificates")]
+    fn new_panics_on_unmerged_two_round_wave() {
+        Wave::new(2, 0, false);
     }
 }

--- a/crates/consensus/tests/indirect_commit_tests.rs
+++ b/crates/consensus/tests/indirect_commit_tests.rs
@@ -3,12 +3,14 @@
 
 //! `indirect_commit` scenario across the protocol matrix.
 //!
-//! Construction varies on `wave_length`:
-//! - `wl == 2`: a single layer at the (collapsed) voting/decision round with
-//!   `(direct_commit_quorum - 1)` voters and the rest non-voters. That's enough
-//!   for the later anchor to reach `anchor_link_size` certificate paths while
-//!   keeping direct commit below threshold.
-//! - `wl >= 3`: `build_split_chain` to the voting round with enough voters to
+//! Construction varies on the certificate geometry:
+//! - merged certificates (the `wl == 2` protocols, async Blue Bottle at
+//!   `wl == 3`): a split chain to the
+//!   (collapsed) voting/decision round with `(direct_commit_quorum - 1)` voters
+//!   and the rest non-voters. That's enough for the later anchor to reach
+//!   `anchor_link_size` certificate paths while keeping direct commit below
+//!   threshold.
+//! - vote-and-certify: `build_split_chain` to the voting round with enough voters to
 //!   back a certificate (`certificate_quorum`, capped one below the fast-path
 //!   commit quorum so fast-path protocols stay undecided at the voting round),
 //!   then a hand-crafted decision-round layer where only
@@ -67,7 +69,7 @@ fn run(spec: &ConsensusProtocol, committee: &Arc<Committee>) {
         let voting_round = committer.voting_round_for(l1);
         let decision_round = committer.decision_round_for(l1);
 
-        let top_refs = if protocol.wave_length == 2 {
+        let top_refs = if protocol.merged_certificates {
             let voters_count = (protocol.direct_commit_quorum - 1) as usize;
             let blamers_count = committee.len() - voters_count;
             let (supports, blames) = build_split_chain(

--- a/crates/simulator/examples/single.yaml
+++ b/crates/simulator/examples/single.yaml
@@ -29,7 +29,7 @@ replica_parameters:
     fsync: false
   # Consensus protocol variant. Options:
   #   mysticeti                            { leader_count }
-  #   blue-bottle                          { leader_count }
+  #   blue-bottle-partially-synchronous    { leader_count }
   #   orcaella                             { leader_count, f, c }
   #   mahi-mahi                            { leader_count, wave_length: 4 | 5 }
   #   nemo-nemo                            { leader_count }

--- a/crates/simulator/examples/single.yaml
+++ b/crates/simulator/examples/single.yaml
@@ -30,6 +30,7 @@ replica_parameters:
   # Consensus protocol variant. Options:
   #   mysticeti                            { leader_count }
   #   blue-bottle-partially-synchronous    { leader_count }
+  #   blue-bottle-asynchronous             { leader_count }
   #   orcaella                             { leader_count, f, c }
   #   mahi-mahi                            { leader_count, wave_length: 4 | 5 }
   #   nemo-nemo                            { leader_count }


### PR DESCRIPTION
Closes #238 (part of #237).

Two commits, meant for rebase-merge:

1. **refactor(consensus): explicit vote-quorum certificates and Blue Bottle PS naming** — `is_certificate` becomes a quorum check over a set of votes (matching the BlueBottle paper's certificate definitions) with `carries_certificate` for the vote-and-certify pattern; the hidden `wave_length == 2` special case becomes an explicit `Protocol::merged_certificates` flag; Blue Bottle is renamed to its partially synchronous variant, mirroring the Cordial Miners naming. Verified behavior- and performance-preserving for every existing protocol (call-sequence, allocation, and lock parity audited; the one delta found — a new per-vote TRACE on the wl=2 path — is gated off).
2. **feat(consensus): add asynchronous Blue Bottle variant** — wave length 3 with merged certificates: a strong quorum (4f+1) of decision-round supports direct-commits at r+2, a strong quorum of non-supports direct-skips, and a weak quorum (2f+1) of anchor-linked supports drives the indirect rule; no leader wait; round-robin stands in for the hidden coin leader until #242. The full per-protocol scenario matrix now exercises the variant.

Breaking naming note: the config tag `blue-bottle` becomes `blue-bottle-partially-synchronous` and result identifiers `blue-bottle-l*` become `blue-bottle-ps-l*`; out-of-repo settings files and previously collected result sets need renaming to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014c1nBxpzhrzCpXHMoZrZcZ